### PR TITLE
Update target field to comply with KRM conventions

### DIFF
--- a/constraint/README.md
+++ b/constraint/README.md
@@ -59,7 +59,7 @@ spec:
               type: array
               items: string
   targets:
-    admission.k8s.gatekeeper.sh:
+    - target: admission.k8s.gatekeeper.sh
       rego: |
 deny[{"msg": msg, "details": {"missing_labels": missing}}] {
    provided := {label | input.request.object.metadata.labels[label]}
@@ -73,7 +73,8 @@ deny[{"msg": msg, "details": {"missing_labels": missing}}] {
 The most important pieces of the above YAML are:
 
    * `validation`, which provides the schema for the `parameters` field for the constraint
-   * `targets`, which specifies what "target" (defined later) the constraint applies to. Note that currently constraints can only apply to one target.
+   * `targets`, which specifies what "target" (defined later) the constraint applies to. Note
+      that currently constraints can only apply to one target.
    * `rego`, which defines the logic that enforces the constraint.
  
  #### Rego Semantics for Constraints

--- a/constraint/config/crds/templates_v1alpha1_constrainttemplate.yaml
+++ b/constraint/config/crds/templates_v1alpha1_constrainttemplate.yaml
@@ -39,7 +39,14 @@ spec:
                   type: object
               type: object
             targets:
-              type: object
+              items:
+                properties:
+                  rego:
+                    type: string
+                  target:
+                    type: string
+                type: object
+              type: array
           type: object
         status:
           properties:

--- a/constraint/pkg/apis/templates/v1alpha1/constrainttemplate_types.go
+++ b/constraint/pkg/apis/templates/v1alpha1/constrainttemplate_types.go
@@ -25,8 +25,8 @@ import (
 
 // ConstraintTemplateSpec defines the desired state of ConstraintTemplate
 type ConstraintTemplateSpec struct {
-	CRD     CRD               `json:"crd,omitempty"`
-	Targets map[string]Target `json:"targets,omitempty"`
+	CRD     CRD      `json:"crd,omitempty"`
+	Targets []Target `json:"targets,omitempty"`
 }
 
 type CRD struct {
@@ -43,7 +43,8 @@ type Validation struct {
 }
 
 type Target struct {
-	Rego string `json:"rego,omitempty"`
+	Target string `json:"target,omitempty"`
+	Rego   string `json:"rego,omitempty"`
 }
 
 // ConstraintTemplateStatus defines the observed state of ConstraintTemplate

--- a/constraint/pkg/apis/templates/v1alpha1/zz_generated.deepcopy.go
+++ b/constraint/pkg/apis/templates/v1alpha1/zz_generated.deepcopy.go
@@ -128,10 +128,8 @@ func (in *ConstraintTemplateSpec) DeepCopyInto(out *ConstraintTemplateSpec) {
 	in.CRD.DeepCopyInto(&out.CRD)
 	if in.Targets != nil {
 		in, out := &in.Targets, &out.Targets
-		*out = make(map[string]Target, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
+		*out = make([]Target, len(*in))
+		copy(*out, *in)
 	}
 	return
 }

--- a/constraint/pkg/client/client.go
+++ b/constraint/pkg/client/client.go
@@ -213,7 +213,8 @@ func (c *client) CreateCRD(ctx context.Context, templ *v1alpha1.ConstraintTempla
 
 	var src string
 	var target TargetHandler
-	for k, v := range templ.Spec.Targets {
+	for _, v := range templ.Spec.Targets {
+		k := v.Target
 		t, ok := c.targets[k]
 		if !ok {
 			return nil, fmt.Errorf("Target %s not recognized", k)
@@ -249,7 +250,8 @@ func (c *client) AddTemplate(ctx context.Context, templ *v1alpha1.ConstraintTemp
 
 	var src string
 	var target TargetHandler
-	for k, v := range templ.Spec.Targets {
+	for _, v := range templ.Spec.Targets {
+		k := v.Target
 		t, ok := c.targets[k]
 		if !ok {
 			return resp, fmt.Errorf("Target %s not recognized", k)
@@ -285,7 +287,8 @@ func (c *client) RemoveTemplate(ctx context.Context, templ *v1alpha1.ConstraintT
 	}
 
 	var target TargetHandler
-	for k := range templ.Spec.Targets {
+	for _, v := range templ.Spec.Targets {
+		k := v.Target
 		t, ok := c.targets[k]
 		if !ok {
 			return resp, fmt.Errorf("Target %s not recognized", k)

--- a/constraint/pkg/client/client_test.go
+++ b/constraint/pkg/client/client_test.go
@@ -292,9 +292,7 @@ func TestRemoveData(t *testing.T) {
 
 func TestAddTemplate(t *testing.T) {
 	badRegoTempl := createTemplate(name("fakes"), crdNames("Fake", "fakes"), targets("h1"))
-	r := badRegoTempl.Spec.Targets["h1"]
-	r.Rego = "asd{"
-	badRegoTempl.Spec.Targets["h1"] = r
+	badRegoTempl.Spec.Targets[0].Rego = "asd{"
 	tc := []struct {
 		Name          string
 		Handler       TargetHandler
@@ -368,9 +366,7 @@ func TestAddTemplate(t *testing.T) {
 
 func TestRemoveTemplate(t *testing.T) {
 	badRegoTempl := createTemplate(name("fake"), crdNames("Fake", "fakes"), targets("h1"))
-	r := badRegoTempl.Spec.Targets["h1"]
-	r.Rego = "asd{"
-	badRegoTempl.Spec.Targets["h1"] = r
+	badRegoTempl.Spec.Targets[0].Rego = "asd{"
 	tc := []struct {
 		Name          string
 		Handler       TargetHandler

--- a/constraint/pkg/client/crd_helpers_test.go
+++ b/constraint/pkg/client/crd_helpers_test.go
@@ -40,9 +40,9 @@ func schema(pm propMap) tmplArg {
 }
 
 func targets(ts ...string) tmplArg {
-	targets := make(map[string]v1alpha1.Target, len(ts))
-	for _, t := range ts {
-		targets[t] = v1alpha1.Target{Rego: "package hello v{1 == 1}"}
+	targets := make([]v1alpha1.Target, len(ts))
+	for i, t := range ts {
+		targets[i] = v1alpha1.Target{Target: t, Rego: "package hello v{1 == 1}"}
 	}
 
 	return func(tmpl *v1alpha1.ConstraintTemplate) {

--- a/constraint/pkg/client/e2e_tests.go
+++ b/constraint/pkg/client/e2e_tests.go
@@ -37,8 +37,8 @@ func newConstraintTemplate(name, rego string) *v1alpha1.ConstraintTemplate {
 					},
 				},
 			},
-			Targets: map[string]v1alpha1.Target{
-				"test.target": v1alpha1.Target{Rego: rego},
+			Targets: []v1alpha1.Target{
+				v1alpha1.Target{Target: "test.target", Rego: rego},
 			},
 		},
 	}


### PR DESCRIPTION
Maps are disfavored compared to lists:

https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#lists-of-named-subobjects-preferred-over-maps

Not using a "name" field because we may want to have multiple targets in the future.