### PR TITLE
Move arity check to Create CRD to allow wrong-arity to fail faster

### DIFF
--- a/constraint/pkg/client/client.go
+++ b/constraint/pkg/client/client.go
@@ -243,6 +243,14 @@ func (c *client) CreateCRD(ctx context.Context, templ *v1alpha1.ConstraintTempla
 	}
 
 	path := createTemplatePath(target.GetName(), crd.Spec.Names.Kind)
+
+	req := ruleArities{
+		"violation": 1,
+	}
+	if err := requireRules(path, src, req); err != nil {
+		return nil, fmt.Errorf("Invalid rego: %s", err)
+	}
+
 	_, err := ensureRegoConformance(crd.Spec.Names.Kind, path, src)
 	if err != nil {
 		return nil, err
@@ -274,14 +282,6 @@ func (c *client) AddTemplate(ctx context.Context, templ *v1alpha1.ConstraintTemp
 	}
 
 	path := createTemplatePath(target.GetName(), crd.Spec.Names.Kind)
-
-	req := ruleArities{
-		"violation": 1,
-	}
-	if err := requireRules(path, src, req); err != nil {
-		return resp, fmt.Errorf("Invalid rego: %s", err)
-	}
-
 	conformingSrc, err := ensureRegoConformance(crd.Spec.Names.Kind, path, src)
 	if err != nil {
 		return resp, err


### PR DESCRIPTION
Signed-off-by: Max Smythe <smythe@google.com>