### PR TITLE
Create a CRD to define MutationTemplates

### DIFF
--- a/constraint/config/crds/templates_v1alpha1_mutationtemplate.yaml
+++ b/constraint/config/crds/templates_v1alpha1_mutationtemplate.yaml
@@ -1,0 +1,64 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: mutationtemplates.templates.gatekeeper.sh
+spec:
+  group: templates.gatekeeper.sh
+  names:
+    kind: MutationTemplate
+    plural: mutationtemplates
+  scope: Cluster
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            crd:
+              properties:
+                spec:
+                  properties:
+                    names:
+                      type: object
+                    validation:
+                      type: object
+                  type: object
+              type: object
+            targets:
+              items:
+                properties:
+                  rego:
+                    type: string
+                  target:
+                    type: string
+                type: object
+              type: array
+          type: object
+        status:
+          properties:
+            created:
+              type: boolean
+            error:
+              type: string
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/constraint/config/samples/templates_v1alpha1_mutationtemplate.yaml
+++ b/constraint/config/samples/templates_v1alpha1_mutationtemplate.yaml
@@ -1,0 +1,23 @@
+apiVersion: templates.gatekeeper.sh/v1alpha1
+kind: MutationTemplate
+metadata:
+  name: test-mute
+spec:
+  crd:
+    spec:
+      names:
+        kind: MutationThing
+        listKind: MutationThingList
+        plural: MutationThings
+        singular: MutationThing
+      validation:
+        openAPIV3Schema:
+          properties:
+            blockList:
+              type: array
+              items: string
+  targets:
+  - target: admission.k8s.gatekeeper.sh
+    rego: |
+        package MutationThings
+        sprintf("E",[])


### PR DESCRIPTION
Duplicates the ConstraintTemplates CRD and renamed
the kinds to define MutationTemplate(s), templates
that will be used to define a series of Mutations
(Similar to ConstraintTemplates & Constraints)
for a mutating Gatekeeper.

Tested by applying `crds/templates_v1alpha1_mutationtemplate.yaml`
and `samples/templates_v1alpha1_mutationtemplate.yaml` on a GKE cluster,
then searching for `test-mute` in `kubectl get mutationtemplates`.

Signed-off-by: Cameron McCarthy <camm@google.com>