### PR TITLE
Allow for the creation of MutationCRDs alongside Constraint CRDs

### DIFF
--- a/constraint/config/crds/templates_v1alpha1_mutationtemplate.yaml
+++ b/constraint/config/crds/templates_v1alpha1_mutationtemplate.yaml
@@ -17,12 +17,12 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          object represents.Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md'
           type: string
         metadata:
           type: object

--- a/constraint/pkg/apis/templates/v1alpha1/mutationtemplate_types.go
+++ b/constraint/pkg/apis/templates/v1alpha1/mutationtemplate_types.go
@@ -30,13 +30,14 @@ type MutationTemplateSpec struct {
 
 // MutationTemplateStatus defines the observed state of MutationTemplate
 type MutationTemplateStatus struct {
-	Created bool   `json:"created,omitempty"`
-	ByPod []*ByPodStatus `json:"byPod,omitempty"`
+	Created bool           `json:"created,omitempty"`
+	ByPod   []*ByPodStatus `json:"byPod,omitempty"`
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
 // +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // MutationTemplate is the Schema for the mutationtemplates API

--- a/constraint/pkg/apis/templates/v1alpha1/mutationtemplate_types_test.go
+++ b/constraint/pkg/apis/templates/v1alpha1/mutationtemplate_types_test.go
@@ -26,13 +26,11 @@ import (
 
 func TestStorageMutationTemplate(t *testing.T) {
 	key := types.NamespacedName{
-		Name:      "foo",
-		Namespace: "default",
+		Name: "foo",
 	}
 	created := &MutationTemplate{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "foo",
-			Namespace: "default",
+			Name: "foo",
 		}}
 	g := gomega.NewGomegaWithT(t)
 

--- a/constraint/pkg/client/client.go
+++ b/constraint/pkg/client/client.go
@@ -19,7 +19,12 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-const constraintGroup = "constraints.gatekeeper.sh"
+type k8sGroup string
+
+const (
+	constraintGroup k8sGroup = "constraints.gatekeeper.sh"
+	mutationGroup k8sGroup = "mutations.gatekeeper.sh"
+)
 
 type Client interface {
 	AddData(context.Context, interface{}) (*types.Responses, error)
@@ -221,7 +226,7 @@ func (c *client) CreateCRD(ctx context.Context, templ *v1alpha1.ConstraintTempla
 	if err := c.validateGenericCRD(nm, specCRD, targets); err != nil {
 		return nil, err
 	}
-	return c.createGenericCRD(nm, specCRD, targets)
+	return c.createGenericCRD(nm, specCRD, targets, constraintGroup)
 }
 
 func (c *client) CreateMutationCRD(ctx context.Context, templ *v1alpha1.MutationTemplate) (*apiextensionsv1beta1.CustomResourceDefinition, error) {
@@ -231,7 +236,7 @@ func (c *client) CreateMutationCRD(ctx context.Context, templ *v1alpha1.Mutation
 	if err := c.validateGenericCRD(nm, specCRD, targets); err != nil {
 		return nil, err
 	}
-	return c.createGenericCRD(nm, specCRD, targets)
+	return c.createGenericCRD(nm, specCRD, targets, mutationGroup)
 }
 
 func (c *client) validateGenericCRD(objMetaName string, specCRD *v1alpha1.CRD, targets []v1alpha1.Target) error {
@@ -248,7 +253,7 @@ func (c *client) validateGenericCRD(objMetaName string, specCRD *v1alpha1.CRD, t
 	return nil
 }
 
-func (c *client) createGenericCRD(objMetaName string, specCRD *v1alpha1.CRD, targets []v1alpha1.Target) (*apiextensionsv1beta1.CustomResourceDefinition, error){
+func (c *client) createGenericCRD(objMetaName string, specCRD *v1alpha1.CRD, targets []v1alpha1.Target, group k8sGroup) (*apiextensionsv1beta1.CustomResourceDefinition, error){
 	var src string
 	var target TargetHandler
 	for _, v := range targets {
@@ -265,7 +270,7 @@ func (c *client) createGenericCRD(objMetaName string, specCRD *v1alpha1.CRD, tar
 	crdSpecKind := specCRD.Spec.Names.Kind
 
 	schema := createSchema(CRDSpec, target)
-	crd := c.backend.crd.createCRD(crdSpecKind, schema)
+	crd := c.backend.crd.createCRD(crdSpecKind, schema, group)
 	if err := c.backend.crd.validateCRD(crd); err != nil {
 		return nil, err
 	}
@@ -351,7 +356,7 @@ func (c *client) RemoveTemplate(ctx context.Context, templ *v1alpha1.ConstraintT
 	crdSpecKind := templ.Spec.CRD.Spec.Names.Kind
 
 	schema := createSchema(crdSpec, target)
-	crd := c.backend.crd.createCRD(crdSpecKind, schema)
+	crd := c.backend.crd.createCRD(crdSpecKind, schema, constraintGroup)//TODO(camm): make this work for both groups in future
 	if err := c.backend.crd.validateCRD(crd); err != nil {
 		return resp, err
 	}
@@ -410,7 +415,7 @@ func (c *client) AddConstraint(ctx context.Context, constraint *unstructured.Uns
 	defer c.constraintsMux.RUnlock()
 	resp := types.NewResponses()
 	errMap := make(ErrorMap)
-	if err := c.validateConstraint(constraint, false); err != nil {
+	if err := c.validateConstraint(constraint, false, constraintGroup); err != nil {
 		return resp, err
 	}
 	entry, err := c.getConstraintEntry(constraint, false)
@@ -468,12 +473,12 @@ func (c *client) RemoveConstraint(ctx context.Context, constraint *unstructured.
 
 // validateConstraint is an internal function that allows us to toggle whether we use a read lock
 // when validating a constraint
-func (c *client) validateConstraint(constraint *unstructured.Unstructured, lock bool) error {
+func (c *client) validateConstraint(constraint *unstructured.Unstructured, lock bool, group k8sGroup) error {
 	entry, err := c.getConstraintEntry(constraint, lock)
 	if err != nil {
 		return err
 	}
-	if err = c.backend.crd.validateCR(constraint, entry.CRD); err != nil {
+	if err = c.backend.crd.validateCR(constraint, entry.CRD, group); err != nil {
 		return err
 	}
 
@@ -488,7 +493,13 @@ func (c *client) validateConstraint(constraint *unstructured.Unstructured, lock 
 // ValidateConstraint returns an error if the constraint is not recognized or does not conform to
 // the registered CRD for that constraint.
 func (c *client) ValidateConstraint(ctx context.Context, constraint *unstructured.Unstructured) error {
-	return c.validateConstraint(constraint, true)
+	return c.validateConstraint(constraint, true, constraintGroup)
+}
+
+// ValidateMutation returns an error if the constraint is not recognized or does not conform to
+// the registered CRD for that constraint.
+func (c *client) ValidateMutation(ctx context.Context, constraint *unstructured.Unstructured) error {
+	return c.validateConstraint(constraint, true, mutationGroup)
 }
 
 // init initializes the OPA backend for the client

--- a/constraint/pkg/client/crd_helpers_test.go
+++ b/constraint/pkg/client/crd_helpers_test.go
@@ -118,7 +118,7 @@ func gvk(group, version, kind string) customResourceArg {
 }
 
 func kind(kind string) customResourceArg {
-	return gvk(constraintGroup, "v1alpha1", kind)
+	return gvk(string(constraintGroup), "v1alpha1", kind)
 }
 
 func params(s string) customResourceArg {
@@ -300,7 +300,7 @@ func TestCRDCreationAndValidation(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
 			schema := createSchema(tc.Template.Spec.CRD.Spec, tc.Handler)
-			crd := h.createCRD(tc.Template.Spec.CRD.Spec.Names.Kind, schema)
+			crd := h.createCRD(tc.Template.Spec.CRD.Spec.Names.Kind, schema, constraintGroup)
 			err := h.validateCRD(crd)
 			if (err == nil) && tc.ErrorExpected {
 				t.Errorf("err = nil; want non-nil")
@@ -384,7 +384,7 @@ func TestCRValidation(t *testing.T) {
 				crdNames("Horse"),
 			),
 			Handler:       createTestTargetHandler(),
-			CR:            createCR(crName("mycr"), gvk(constraintGroup, "badversion", "Horse")),
+			CR:            createCR(crName("mycr"), gvk(string(constraintGroup), "badversion", "Horse")),
 			ErrorExpected: true,
 		},
 		{
@@ -435,11 +435,11 @@ func TestCRValidation(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
 			schema := createSchema(tc.Template.Spec.CRD.Spec, tc.Handler)
-			crd := h.createCRD(tc.Template.Spec.CRD.Spec.Names.Kind, schema)
+			crd := h.createCRD(tc.Template.Spec.CRD.Spec.Names.Kind, schema, constraintGroup)
 			if err := h.validateCRD(crd); err != nil {
 				t.Errorf("Bad test setup: Bad CRD: %s", err)
 			}
-			err := h.validateCR(tc.CR, crd)
+			err := h.validateCR(tc.CR, crd, constraintGroup)
 			if (err == nil) && tc.ErrorExpected {
 				t.Errorf("err = nil; want non-nil")
 			}

--- a/constraint/pkg/client/crd_helpers_test.go
+++ b/constraint/pkg/client/crd_helpers_test.go
@@ -186,7 +186,7 @@ func TestValidateTemplate(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
-			err := validateTargets(tc.Template)
+			err := validateTargets(tc.Template.Spec.Targets)
 			if (err == nil) && tc.ErrorExpected {
 				t.Errorf("err = nil; want non-nil")
 			}
@@ -240,9 +240,9 @@ func TestCreateSchema(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
-			schema := createSchema(tc.Template, tc.Handler)
+			schema := createSchema(tc.Template.Spec.CRD.Spec, tc.Handler)
 			if !reflect.DeepEqual(schema, tc.ExpectedSchema) {
-				t.Errorf("createSchema(%#v) = \n%#v; \nwant %#v", tc.Template, *schema, *tc.ExpectedSchema)
+				t.Errorf("createSchema(%#v) = \n%#v; \nwant %#v", tc.Template.Spec.CRD.Spec, *schema, *tc.ExpectedSchema)
 			}
 		})
 	}
@@ -299,8 +299,8 @@ func TestCRDCreationAndValidation(t *testing.T) {
 	h := newCRDHelper()
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
-			schema := createSchema(tc.Template, tc.Handler)
-			crd := h.createCRD(tc.Template, schema)
+			schema := createSchema(tc.Template.Spec.CRD.Spec, tc.Handler)
+			crd := h.createCRD(tc.Template.Spec.CRD.Spec.Names.Kind, schema)
 			err := h.validateCRD(crd)
 			if (err == nil) && tc.ErrorExpected {
 				t.Errorf("err = nil; want non-nil")
@@ -434,8 +434,8 @@ func TestCRValidation(t *testing.T) {
 	h := newCRDHelper()
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
-			schema := createSchema(tc.Template, tc.Handler)
-			crd := h.createCRD(tc.Template, schema)
+			schema := createSchema(tc.Template.Spec.CRD.Spec, tc.Handler)
+			crd := h.createCRD(tc.Template.Spec.CRD.Spec.Names.Kind, schema)
 			if err := h.validateCRD(crd); err != nil {
 				t.Errorf("Bad test setup: Bad CRD: %s", err)
 			}


### PR DESCRIPTION
Refactored OPA client code and introduced a few Mutation variants of Client functions to allow them to accept MutationTemplates and then build appropriate Mutation CRD Go objects. Tested mainly with `go test` at the package level, and then later copying diffs into a new Gatekeeper image and running that on a GKE cluster.