### PR TITLE
Cleaned up Dockerfile to reduce image size

### DIFF
--- a/constraint/Dockerfile
+++ b/constraint/Dockerfile
@@ -1,29 +1,30 @@
 # Build the manager binary
 FROM golang:1.10.3 as builder
 
-RUN apt-get update && apt-get install -y apt-utils
-RUN apt-get install -y make
+RUN apt-get update &&\
+    apt-get install -y apt-utils make
 
 # Install kubebuilder
 WORKDIR /scratch
 ENV version=1.0.8
 ENV arch=amd64
-RUN curl -L -O "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/kubebuilder_${version}_linux_${arch}.tar.gz"
-RUN tar -zxvf kubebuilder_${version}_linux_${arch}.tar.gz
-RUN mv kubebuilder_${version}_linux_${arch} kubebuilder && mv kubebuilder /usr/local/
+RUN curl -L -O "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/kubebuilder_${version}_linux_${arch}.tar.gz" &&\
+    tar -zxvf kubebuilder_${version}_linux_${arch}.tar.gz &&\
+    mv kubebuilder_${version}_linux_${arch} /usr/local/kubebuilder &&\
+    rm kubebuilder_${version}_linux_${arch}.tar.gz
 ENV PATH=$PATH:/usr/local/kubebuilder/bin:/usr/bin
 
 # Install kustomize
 ENV version=3.0.2
 ENV arch=amd64
-RUN curl -L -O "https://github.com/kubernetes-sigs/kustomize/releases/download/v${version}/kustomize_${version}_linux_${arch}"
-RUN mv kustomize_${version}_linux_${arch} /usr/bin/kustomize
-RUN chmod u+x /usr/bin/kustomize
+RUN curl -L -O "https://github.com/kubernetes-sigs/kustomize/releases/download/v${version}/kustomize_${version}_linux_${arch}" &&\
+    mv kustomize_${version}_linux_${arch} /usr/bin/kustomize &&\
+    chmod u+x /usr/bin/kustomize
 
 # Install OPA
 WORKDIR /usr/bin
-RUN curl -L -o opa https://github.com/open-policy-agent/opa/releases/download/v0.10.5/opa_linux_amd64
-RUN chmod 755 opa
+RUN curl -L -o opa https://github.com/open-policy-agent/opa/releases/download/v0.10.5/opa_linux_amd64 &&\
+    chmod 755 opa
 
 # Copy in the go src
 WORKDIR /go/src/github.com/open-policy-agent/frameworks/constraint


### PR DESCRIPTION
Shaved 300+ MB from docker image:

dmitrytokarev/opa-frameworks                untrimmed                  4849ca580d5e        3 minutes ago       1.45GB
dmitrytokarev/opa-frameworks                trimmed                    1cda21aef183        6 minutes ago       1.12GB

To further reduce size I propose using `FROM golang:1.10.3-alpine` it will reduce size by ~500 MB:
golang                                      1.10.3-alpine              cace225819dc        14 months ago       259MB
golang                                      1.10.3                     d0e7a411e3da        15 months ago       794MB
