### PR TITLE
remove constraints from the 'all' category

### DIFF
--- a/constraint/pkg/client/crd_helpers.go
+++ b/constraint/pkg/client/crd_helpers.go
@@ -87,7 +87,6 @@ func (h *crdHelper) createCRD(
 				Singular:   strings.ToLower(templ.Spec.CRD.Spec.Names.Kind),
 				ShortNames: templ.Spec.CRD.Spec.Names.ShortNames,
 				Categories: []string{
-					"all",
 					"constraint",
 				},
 			},


### PR DESCRIPTION
Users without the appropriate cluster-level permissions receive errors like this when running `kubectl get all`:
```
Error from server (Forbidden): k8srequiredlabels.constraints.gatekeeper.sh is forbidden: User "user" cannot list resource "k8srequiredlabels" in API group "constraints.gatekeeper.sh" at the cluster scope
```

As far as I know, there are no other cluster-scoped resources in the all category, so constraints don't belong there either.

https://github.com/kubernetes/community/blob/master/contributors/devel/sig-cli/kubectl-conventions.md#rules-for-extending-special-resource-alias---all