### PR TITLE
Support external vendoring of manifests using go toolchain

### DIFF
--- a/constraint/deploy/tools.go
+++ b/constraint/deploy/tools.go
@@ -1,0 +1,4 @@
+// +build tools
+
+// This existence of this package allows vendoring of the manifests in this directory by go 1.13+.
+package tools


### PR DESCRIPTION
Add a build tag gated "tools" package to allow a dependent to vendor constraint template manifests using the standard go toolchain.
The standard `go mod vendor` command will prune non-go packages as described in https://github.com/golang/go/issues/26366.

We can cause a directory to be a go package by including a conditionally compiled go source file that does nothing.
This trick is documented [here](https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module).

Subsequently, a dependent module can vendor our manifests using a similar trick:

```
// +build tools

package tools

import _ "github.com/open-policy-agent/frameworks/constraint/deploy"
```

Closes #84

Signed-off-by: Oren Shomron <shomrono@vmware.com>