### PR TITLE
pkg/client: Remove rule 'arity' check

### DIFF
--- a/constraint/pkg/client/client.go
+++ b/constraint/pkg/client/client.go
@@ -309,9 +309,8 @@ func (c *Client) createTemplateArtifacts(templ *templates.ConstraintTemplate) (*
 		return nil, err
 	}
 
-	req := ruleArities{
-		"violation": 1,
-	}
+	req := map[string]struct{}{"violation": struct{}{}}
+
 	if err := requireRulesModule(entryPoint, req); err != nil {
 		return nil, fmt.Errorf("Invalid rego: %s", err)
 	}
@@ -693,10 +692,10 @@ func (c *Client) init() error {
 			return err
 		}
 		lib := libBuf.String()
-		req := ruleArities{
-			"autoreject_review":                1,
-			"matching_reviews_and_constraints": 2,
-			"matching_constraints":             1,
+		req := map[string]struct{}{
+			"autoreject_review":                struct{}{},
+			"matching_reviews_and_constraints": struct{}{},
+			"matching_constraints":             struct{}{},
 		}
 		path := fmt.Sprintf("%s.library", hooks)
 		libModule, err := parseModule(path, lib)

--- a/constraint/pkg/client/client_test.go
+++ b/constraint/pkg/client/client_test.go
@@ -298,14 +298,7 @@ func TestRemoveData(t *testing.T) {
 func TestAddTemplate(t *testing.T) {
 	badRegoTempl := createTemplate(name("fake"), crdNames("Fake"), targets("h1"))
 	badRegoTempl.Spec.Targets[0].Rego = badRego
-	badArityTempl := createTemplate(name("fake"), crdNames("Fake"), targets("h1"))
-	badArityTempl.Spec.Targets[0].Rego = `
-package foo
 
-violation {
-	true
-}
-`
 	missingRuleTempl := createTemplate(name("fake"), crdNames("Fake"), targets("h1"))
 	missingRuleTempl.Spec.Targets[0].Rego = `
 package foo
@@ -357,12 +350,6 @@ some_rule[r] {
 			Name:          "No Rego",
 			Handler:       &badHandler{Name: "h1", HasLib: true},
 			Template:      emptyRegoTempl,
-			ErrorExpected: true,
-		},
-		{
-			Name:          "Bad Arity",
-			Handler:       &badHandler{Name: "h1", HasLib: true},
-			Template:      badArityTempl,
 			ErrorExpected: true,
 		},
 		{

--- a/constraint/pkg/client/rego_helpers_test.go
+++ b/constraint/pkg/client/rego_helpers_test.go
@@ -2,8 +2,6 @@ package client
 
 import (
 	"testing"
-
-	"github.com/open-policy-agent/opa/ast"
 )
 
 type regoTestCase struct {
@@ -13,75 +11,7 @@ type regoTestCase struct {
 	ErrorExpected bool
 	ExpectedRego  string
 	ArityExpected int
-	RequiredRules ruleArities
-}
-
-func TestGetRuleArity(t *testing.T) {
-	tc := []regoTestCase{
-		{
-			Name:          "Nullary",
-			Rego:          `package hello v{1 == 1}`,
-			ArityExpected: 0,
-		},
-		{
-			Name:          "Unary",
-			Rego:          `package hello v[r]{r == 1}`,
-			ArityExpected: 1,
-		},
-		{
-			Name:          "Object is unary",
-			Rego:          `package hello v[{"arg": a}]{a == 1}`,
-			ArityExpected: 1,
-		},
-		{
-			Name:          "Binary",
-			Rego:          `package hello v[[r, d]]{r == 1; d == 2}`,
-			ArityExpected: 2,
-		},
-		{
-			Name:          "5-ary",
-			Rego:          `package hello v[[a, b, c, d, e]]{a == 1; b == 2; c == 3; d == 4; e == 5 }`,
-			ArityExpected: 5,
-		},
-		{
-			Name:          "Object in Array Allowed",
-			Rego:          `package hello v[[{"arg": a}, b]]{a == 1; b == 2}`,
-			ArityExpected: 2,
-		},
-		{
-			Name:          "No String Key",
-			Rego:          `package hello v["q"]{1 == 1}`,
-			ErrorExpected: true,
-		},
-		{
-			Name:          "No String Array Entry",
-			Rego:          `package hello v[[b, "a"]]{b == 2}`,
-			ErrorExpected: true,
-		},
-		{
-			Name:          "No String Array Entry (reversed)",
-			Rego:          `package hello v[["a", b]]{b == 2}`,
-			ErrorExpected: true,
-		},
-	}
-	for _, tt := range tc {
-		t.Run(tt.Name, func(t *testing.T) {
-			module, err := ast.ParseModule("foo", tt.Rego)
-			if err != nil {
-				t.Fatalf("Error parsing rego: %s", err)
-			}
-			arity, err := getRuleArity(module.Rules[0])
-			if (err == nil) && tt.ErrorExpected {
-				t.Fatalf("err = nil; want non-nil")
-			}
-			if (err != nil) && !tt.ErrorExpected {
-				t.Fatalf("err = \"%s\"; want nil", err)
-			}
-			if arity != tt.ArityExpected {
-				t.Errorf("getRuleArity(%s) = %d, want %d", tt.Rego, arity, tt.ArityExpected)
-			}
-		})
-	}
+	RequiredRules map[string]struct{}
 }
 
 func TestRequireRules(t *testing.T) {
@@ -99,49 +29,25 @@ func TestRequireRules(t *testing.T) {
 		{
 			Name:          "Required Rule",
 			Rego:          `package hello r{1 == 1}`,
-			RequiredRules: ruleArities{"r": 0},
-			ErrorExpected: false,
-		},
-		{
-			Name:          "Required Rule Unary",
-			Rego:          `package hello r[v]{v == 1}`,
-			RequiredRules: ruleArities{"r": 1},
-			ErrorExpected: false,
-		},
-		{
-			Name:          "Required Rule Binary",
-			Rego:          `package hello r[[v, q]]{v == 1; q == 2}`,
-			RequiredRules: ruleArities{"r": 2},
+			RequiredRules: map[string]struct{}{"r": struct{}{}},
 			ErrorExpected: false,
 		},
 		{
 			Name:          "Required Rule Extras",
 			Rego:          `package hello r[v]{v == 1} q{3 == 3}`,
-			RequiredRules: ruleArities{"r": 1},
+			RequiredRules: map[string]struct{}{"r": struct{}{}},
 			ErrorExpected: false,
 		},
 		{
 			Name:          "Required Rule Multiple",
 			Rego:          `package hello r[v]{v == 1} q{3 == 3}`,
-			RequiredRules: ruleArities{"r": 1, "q": 0},
+			RequiredRules: map[string]struct{}{"r": struct{}{}, "q": struct{}{}},
 			ErrorExpected: false,
 		},
 		{
 			Name:          "Required Rule Missing",
 			Rego:          `package hello`,
-			RequiredRules: ruleArities{"r": 0},
-			ErrorExpected: true,
-		},
-		{
-			Name:          "Required Rule Wrong Arity",
-			Rego:          `package hello r{1 == 1}`,
-			RequiredRules: ruleArities{"r": 1},
-			ErrorExpected: true,
-		},
-		{
-			Name:          "Required Rule Missing, Multiple",
-			Rego:          `package hello r{1 == 1}`,
-			RequiredRules: ruleArities{"r": 0, "q": 0},
+			RequiredRules: map[string]struct{}{"r": struct{}{}},
 			ErrorExpected: true,
 		},
 	}


### PR DESCRIPTION
Previously the client implemented internal checks to catch syntactic
mistakes with certain rules (e.g,. `violation`,
`matching_constraints`, etc.) With
https://github.com/open-policy-agent/opa/pull/2579 we are changing the
ast.Array type to pave the way for improved performance. This commit
preemptively updates the constraint framework to remove the dependency
on ast.Array. Note, the checks that have been removed were only
best-effort because rules are free to include variables in the
head/key. The checks have been simplified to just look for required
rules (i.e., the key is ignored.)

Signed-off-by: Torin Sandall <torinsandall@gmail.com>