### PR TITLE
Label constraint CRDs to query them more easily 

### DIFF
--- a/constraint/pkg/client/crd_helpers.go
+++ b/constraint/pkg/client/crd_helpers.go
@@ -132,6 +132,7 @@ func (h *crdHelper) createCRD(
 		return nil, err
 	}
 	crd2.ObjectMeta.Name = fmt.Sprintf("%s.%s", crd.Spec.Names.Plural, constraintGroup)
+	crd2.ObjectMeta.Labels = map[string]string{"gatekeeper.sh/constraint": "yes"}
 	return crd2, nil
 }
 

--- a/constraint/pkg/client/crd_helpers_test.go
+++ b/constraint/pkg/client/crd_helpers_test.go
@@ -339,6 +339,8 @@ func TestCRDCreationAndValidation(t *testing.T) {
 			crd, err := h.createCRD(tc.Template, schema)
 			if err != nil {
 				t.Errorf("err = %v; want nil", err)
+			} else if val, ok := crd.ObjectMeta.Labels["gatekeeper.sh/constraint"]; !ok || val != "yes" {
+				t.Errorf("Wanted label gatekeeper.sh/constraint as yes. but obtained %s", val)
 			}
 			err = h.validateCRD(crd)
 			if (err == nil) && tc.ErrorExpected {


### PR DESCRIPTION
This PR provides an answer for https://github.com/open-policy-agent/gatekeeper/issues/760
Adds a label gatekeeper.sh/constraint=yes for crds created for constrainttemplates.

```
$ kubectl get crd --show-labels  
NAME                                                 CREATED AT             LABELS  
configs.config.gatekeeper.sh                         2020-09-18T03:32:31Z   gatekeeper.sh/system=yes  
constraintpodstatuses.status.gatekeeper.sh           2020-09-18T03:32:31Z   gatekeeper.sh/system=yes  
constrainttemplatepodstatuses.status.gatekeeper.sh   2020-09-18T03:32:31Z   gatekeeper.sh/system=yes  
constrainttemplates.templates.gatekeeper.sh          2020-09-18T03:32:31Z   controller-tools.k8s.io=1.0,gatekeeper.sh/system=yes  
k8simageregistry.constraints.gatekeeper.sh           2020-09-18T03:32:59Z   gatekeeper.sh/constraint=yes  
```

```
$ kubectl get crd -l gatekeeper.sh/constraint=yes  
NAME                                         CREATED AT  
k8simageregistry.constraints.gatekeeper.sh   2020-09-18T03:32:59Z  
```

If someone point me to the documentation that needs to be updated for this change, if at all needed, I would be glad to make the change to represent this.

This is my first PR to gatekeeper. So thanks for being patient with me.

Signed-off-by: luckoseabraham <luckose4u@gmail.com>