### PR TITLE
Add a new category "constraints" to the generated CRDs.

### DIFF
--- a/constraint/pkg/client/crd_helpers.go
+++ b/constraint/pkg/client/crd_helpers.go
@@ -96,6 +96,7 @@ func (h *crdHelper) createCRD(
 				ShortNames: templ.Spec.CRD.Spec.Names.ShortNames,
 				Categories: []string{
 					"constraint",
+					"constraints",
 				},
 			},
 			Validation: &apiextensions.CustomResourceValidation{

--- a/constraint/pkg/client/crd_helpers_test.go
+++ b/constraint/pkg/client/crd_helpers_test.go
@@ -341,7 +341,11 @@ func TestCRDCreationAndValidation(t *testing.T) {
 				t.Errorf("err = %v; want nil", err)
 			} else if val, ok := crd.ObjectMeta.Labels["gatekeeper.sh/constraint"]; !ok || val != "yes" {
 				t.Errorf("Wanted label gatekeeper.sh/constraint as yes. but obtained %s", val)
+			} else if crd.Spec.Names.Categories[0] != "constraint" ||
+				crd.Spec.Names.Categories[1] != "constraints" {
+				t.Errorf("Generated CRDs are expected to belong to constraint / constraints categories")
 			}
+
 			err = h.validateCRD(crd)
 			if (err == nil) && tc.ErrorExpected {
 				t.Errorf("err = nil; want non-nil")


### PR DESCRIPTION
A user may use kubectl get contraint or get constraints to retrieve all the
crds generated by templates.

Fixes the second item discussed in https://github.com/open-policy-agent/gatekeeper/issues/677 (plus, this will need to be consumed)