### PR TITLE
mirror labels from constraint templates into crd

### DIFF
--- a/constraint/pkg/client/crd_helpers.go
+++ b/constraint/pkg/client/crd_helpers.go
@@ -133,7 +133,14 @@ func (h *crdHelper) createCRD(
 		return nil, err
 	}
 	crd2.ObjectMeta.Name = fmt.Sprintf("%s.%s", crd.Spec.Names.Plural, constraintGroup)
-	crd2.ObjectMeta.Labels = map[string]string{"gatekeeper.sh/constraint": "yes"}
+
+	labels := templ.ObjectMeta.Labels
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels["gatekeeper.sh/constraint"] = "yes"
+	crd2.ObjectMeta.Labels = labels
+
 	return crd2, nil
 }
 

--- a/constraint/pkg/client/crd_helpers_test.go
+++ b/constraint/pkg/client/crd_helpers_test.go
@@ -30,6 +30,12 @@ func crdNames(kind string) tmplArg {
 	}
 }
 
+func labels(labels map[string]string) tmplArg {
+	return func(tmpl *templates.ConstraintTemplate) {
+		tmpl.ObjectMeta.Labels = labels
+	}
+}
+
 func crdSchema(pm propMap) tmplArg {
 	p := prop(pm)
 	return func(tmpl *templates.ConstraintTemplate) {
@@ -285,6 +291,26 @@ func TestCRDCreationAndValidation(t *testing.T) {
 			Template: createTemplate(
 				name("SomeName"),
 				crdNames("Horse"),
+			),
+			Handler:       createTestTargetHandler(),
+			ErrorExpected: false,
+		},
+		{
+			Name: "Most Basic Valid Template With Labels",
+			Template: createTemplate(
+				name("SomeName"),
+				crdNames("Horse"),
+				labels(map[string]string{"horse": "smiley"}),
+			),
+			Handler:       createTestTargetHandler(),
+			ErrorExpected: false,
+		},
+		{
+			Name: "Validtemplate with trying to override system label",
+			Template: createTemplate(
+				name("SomeName"),
+				crdNames("Horse"),
+				labels(map[string]string{"gatekeeper.sh/constraint": "no"}),
 			),
 			Handler:       createTestTargetHandler(),
 			ErrorExpected: false,


### PR DESCRIPTION
This PR provides an answer for https://github.com/open-policy-agent/gatekeeper/issues/760
Mirrors all the labels from the constrainttemplate into the crd.

Will update the go mod in the gatekeeper repo once this is merged.

Signed-off-by: luckoseabraham <luckose4u@gmail.com>