### PR TITLE
Upgrade kubebuilder in test image to 2.3.2

### DIFF
--- a/constraint/Dockerfile
+++ b/constraint/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update &&\
 
 # Install kubebuilder
 WORKDIR /scratch
-ENV version=2.0.1
+ENV version=2.3.2
 ENV arch=amd64
 RUN curl -L -O "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/kubebuilder_${version}_linux_${arch}.tar.gz" &&\
     tar -zxvf kubebuilder_${version}_linux_${arch}.tar.gz &&\


### PR DESCRIPTION
This fixes the unit tests, which are currently broken.

Somehow, I was able to merge my previous PR
(open-policy-agent/frameworks#114) with these tests broken.  They passed
in the GitHub actions, but are failing for me when I run them locally
(without the change in this PR).  I'm not sure how that happened.

I tried upgrading all the way to controller-runtime 3.0.0, but the
developers of that seem to have changed the way the package is
delivered.  Now, only the binary seems to available for download,
instead of a folder full of binaries.  Notably, this leaves out the
binaries for the API server components (etcd, for example) that are used
during unit test runs.

Contributes to open-policy-agent/gatekeeper#550

Signed-off-by: juliankatz <juliankatz@google.com>