### PR TITLE
Preserve unknown fields in ByPodStatus

### DIFF
--- a/constraint/config/crds/templates.gatekeeper.sh_constrainttemplates.yaml
+++ b/constraint/config/crds/templates.gatekeeper.sh_constrainttemplates.yaml
@@ -197,6 +197,7 @@ spec:
                       description: a unique identifier for the pod that wrote the
                         status
                       type: string
+                      x-kubernetes-preserve-unknown-fields: true
                     observedGeneration:
                       format: int64
                       type: integer

--- a/constraint/deploy/crds.yaml
+++ b/constraint/deploy/crds.yaml
@@ -197,6 +197,7 @@ spec:
                       description: a unique identifier for the pod that wrote the
                         status
                       type: string
+                      x-kubernetes-preserve-unknown-fields: true
                     observedGeneration:
                       format: int64
                       type: integer

--- a/constraint/pkg/apis/templates/v1beta1/constrainttemplate_types.go
+++ b/constraint/pkg/apis/templates/v1beta1/constrainttemplate_types.go
@@ -66,6 +66,7 @@ type CreateCRDError struct {
 // ByPodStatus defines the observed state of ConstraintTemplate as seen by
 // an individual controller
 type ByPodStatus struct {
+	// +kubebuilder:pruning:PreserveUnknownFields
 	// a unique identifier for the pod that wrote the status
 	ID                 string           `json:"id,omitempty"`
 	ObservedGeneration int64            `json:"observedGeneration,omitempty"`


### PR DESCRIPTION
A Gatekeeper e2e test is currently failing in
open-policy-agent/gatekeeper#1286 due to the use of the `operations`
field.  This field is added by Gatekeeper, under a ConstraintTemplate's
`byPodsStatus`.  This field relied on the v1beta1 CRD behavior, where
unknown fields are preserved by default.

As this field fundamentally has to do with gatekeeper, it's better not
to define it in the Constraint Framework.  Other CF consumers have no
need for the Operations field.

Even better, we may eventually define ConstraintTemplateSpec in
Constraint Framework consumers, rather than in the library itself.

For now, adding `x-kubernetes-preserve-unknown-fields: true` to
ByPodStatus will solve our problem and maintain the existing behavior.

Contributes to open-policy-agent/gatekeeper#550

Signed-off-by: juliankatz <juliankatz@google.com>