### PR TITLE
Move `x-kub...` alongside byPodStatus `properties`

### DIFF
--- a/constraint/config/crds/templates.gatekeeper.sh_constrainttemplates.yaml
+++ b/constraint/config/crds/templates.gatekeeper.sh_constrainttemplates.yaml
@@ -104,6 +104,7 @@ spec:
                       format: int64
                       type: integer
                   type: object
+                  x-kubernetes-preserve-unknown-fields: true
                 type: array
               created:
                 type: boolean
@@ -197,11 +198,11 @@ spec:
                       description: a unique identifier for the pod that wrote the
                         status
                       type: string
-                      x-kubernetes-preserve-unknown-fields: true
                     observedGeneration:
                       format: int64
                       type: integer
                   type: object
+                  x-kubernetes-preserve-unknown-fields: true
                 type: array
               created:
                 type: boolean

--- a/constraint/deploy/crds.yaml
+++ b/constraint/deploy/crds.yaml
@@ -104,6 +104,7 @@ spec:
                       format: int64
                       type: integer
                   type: object
+                  x-kubernetes-preserve-unknown-fields: true
                 type: array
               created:
                 type: boolean
@@ -197,11 +198,11 @@ spec:
                       description: a unique identifier for the pod that wrote the
                         status
                       type: string
-                      x-kubernetes-preserve-unknown-fields: true
                     observedGeneration:
                       format: int64
                       type: integer
                   type: object
+                  x-kubernetes-preserve-unknown-fields: true
                 type: array
               created:
                 type: boolean

--- a/constraint/pkg/apis/templates/v1alpha1/constrainttemplate_types.go
+++ b/constraint/pkg/apis/templates/v1alpha1/constrainttemplate_types.go
@@ -65,6 +65,7 @@ type CreateCRDError struct {
 
 // ByPodStatus defines the observed state of ConstraintTemplate as seen by
 // an individual controller
+// +kubebuilder:pruning:PreserveUnknownFields
 type ByPodStatus struct {
 	// a unique identifier for the pod that wrote the status
 	ID                 string           `json:"id,omitempty"`

--- a/constraint/pkg/apis/templates/v1beta1/constrainttemplate_types.go
+++ b/constraint/pkg/apis/templates/v1beta1/constrainttemplate_types.go
@@ -65,8 +65,8 @@ type CreateCRDError struct {
 
 // ByPodStatus defines the observed state of ConstraintTemplate as seen by
 // an individual controller
+// +kubebuilder:pruning:PreserveUnknownFields
 type ByPodStatus struct {
-	// +kubebuilder:pruning:PreserveUnknownFields
 	// a unique identifier for the pod that wrote the status
 	ID                 string           `json:"id,omitempty"`
 	ObservedGeneration int64            `json:"observedGeneration,omitempty"`


### PR DESCRIPTION
The previous PR (#117) put the `x-kubernetes-preserve-unknown-fields:
true` key/value pair one level too deep.  This moves it alongside
`byPodStatus`' `properties`.

Contributes to open-policy-agent/gatekeeper#550

Signed-off-by: juliankatz <juliankatz@google.com>