### PR TITLE
Upgrade the CF client to apiextensionsv1

### DIFF
--- a/constraint/pkg/client/client_test.go
+++ b/constraint/pkg/client/client_test.go
@@ -58,7 +58,8 @@ matching_reviews_and_constraints[[r,c]] {r = data.r; c = data.c}`))
 }
 
 func (h *badHandler) MatchSchema() apiextensions.JSONSchemaProps {
-	return apiextensions.JSONSchemaProps{}
+	trueBool := true
+	return apiextensions.JSONSchemaProps{XPreserveUnknownFields: &trueBool}
 }
 
 func (h *badHandler) ProcessData(obj interface{}) (bool, string, interface{}, error) {
@@ -370,6 +371,7 @@ some_rule[r] {
 			if err != nil {
 				t.Fatal(err)
 			}
+
 			r, err := c.AddTemplate(context.Background(), tt.Template)
 			if err != nil && !tt.ErrorExpected {
 				t.Errorf("err = %v; want nil", err)
@@ -377,6 +379,7 @@ some_rule[r] {
 			if err == nil && tt.ErrorExpected {
 				t.Error("err = nil; want non-nil")
 			}
+
 			expectedCount := 0
 			expectedHandled := make(map[string]bool)
 			if !tt.ErrorExpected {
@@ -389,6 +392,7 @@ some_rule[r] {
 			if !reflect.DeepEqual(r.Handled, expectedHandled) {
 				t.Errorf("r.Handled = %v; want %v", r.Handled, expectedHandled)
 			}
+
 			cached, err := c.GetTemplate(context.Background(), tt.Template)
 			if err == nil && tt.ErrorExpected {
 				t.Error("retrieved template when error was expected")

--- a/constraint/pkg/client/crd_helpers.go
+++ b/constraint/pkg/client/crd_helpers.go
@@ -9,7 +9,7 @@ import (
 	"github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/core/templates"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsvalidation "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation"
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -75,7 +75,7 @@ type crdHelper struct {
 
 func newCRDHelper() (*crdHelper, error) {
 	scheme := runtime.NewScheme()
-	if err := apiextensionsv1beta1.AddToScheme(scheme); err != nil {
+	if err := apiextensionsv1.AddToScheme(scheme); err != nil {
 		return nil, err
 	}
 	return &crdHelper{scheme: scheme}, nil
@@ -122,14 +122,14 @@ func (h *crdHelper) createCRD(
 			},
 		},
 	}
-	// Defaulting functions only exist for v1beta1
-	v1b1 := &apiextensionsv1beta1.CustomResourceDefinition{}
-	if err := h.scheme.Convert(crd, v1b1, nil); err != nil {
+	// Defaulting functions are not found in versionless CRD package
+	crdv1 := &apiextensionsv1.CustomResourceDefinition{}
+	if err := h.scheme.Convert(crd, crdv1, nil); err != nil {
 		return nil, err
 	}
-	h.scheme.Default(v1b1)
+	h.scheme.Default(crdv1)
 	crd2 := &apiextensions.CustomResourceDefinition{}
-	if err := h.scheme.Convert(v1b1, crd2, nil); err != nil {
+	if err := h.scheme.Convert(crdv1, crd2, nil); err != nil {
 		return nil, err
 	}
 	crd2.ObjectMeta.Name = fmt.Sprintf("%s.%s", crd.Spec.Names.Plural, constraintGroup)
@@ -146,7 +146,7 @@ func (h *crdHelper) createCRD(
 
 // validateCRD calls the CRD package's validation on an internal representation of the CRD
 func (h *crdHelper) validateCRD(crd *apiextensions.CustomResourceDefinition) error {
-	errors := apiextensionsvalidation.ValidateCustomResourceDefinition(crd, apiextensionsv1beta1.SchemeGroupVersion)
+	errors := apiextensionsvalidation.ValidateCustomResourceDefinition(crd, apiextensionsv1.SchemeGroupVersion)
 	if len(errors) > 0 {
 		return errors.ToAggregate()
 	}

--- a/constraint/pkg/client/crd_helpers_test.go
+++ b/constraint/pkg/client/crd_helpers_test.go
@@ -82,6 +82,11 @@ type testTargetHandler struct {
 
 func createTestTargetHandler(args ...targetHandlerArg) MatchSchemaProvider {
 	h := &testTargetHandler{}
+
+	// The default matchSchema is empty, and thus lacks type information
+	trueBool := true
+	h.matchSchema.XPreserveUnknownFields = &trueBool
+
 	for _, arg := range args {
 		arg(h)
 	}
@@ -99,7 +104,8 @@ type propMap map[string]apiextensions.JSONSchemaProps
 // prop currently expects 0 or 1 prop map. More is unsupported.
 func prop(pm ...map[string]apiextensions.JSONSchemaProps) apiextensions.JSONSchemaProps {
 	if len(pm) == 0 {
-		return apiextensions.JSONSchemaProps{}
+		trueBool := true
+		return apiextensions.JSONSchemaProps{XPreserveUnknownFields: &trueBool}
 	}
 	return apiextensions.JSONSchemaProps{Type: "object", Properties: pm[0]}
 }

--- a/constraint/pkg/client/e2e_tests.go
+++ b/constraint/pkg/client/e2e_tests.go
@@ -35,6 +35,7 @@ func newConstraintTemplate(name, rego string, libs ...string) *templates.Constra
 					},
 					Validation: &templates.Validation{
 						OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
+							Type: "object",
 							Properties: map[string]apiextensions.JSONSchemaProps{
 								"expected": {Type: "string"},
 							},

--- a/constraint/pkg/client/test_handler.go
+++ b/constraint/pkg/client/test_handler.go
@@ -102,6 +102,7 @@ func (h *handler) HandleViolation(result *types.Result) error {
 
 func (h *handler) MatchSchema() apiextensions.JSONSchemaProps {
 	return apiextensions.JSONSchemaProps{
+		Type: "object",
 		Properties: map[string]apiextensions.JSONSchemaProps{
 			"label": {Type: "string"},
 		},


### PR DESCRIPTION
This PR upgrades the Constraint Framework client to use the
apiextensionsv1 library for handling CRDs.  This is necessary for
supporting k8s 1.22, where apiextensionsv1beta1 CRDs are removed.

Crucially, this change switches CF to use the v1 CRD defaulting
functions, which do not set Spec.PreserveUnknownFields.  This field set
to true by default in v1beta1 CRD, but is disallowed in v1 CRD.  This
was preventing me from doing the same apiextensionsv1beta1 -->
apiextensionsv1 upgrade in Gatekeeper.

Contributes to open-policy-agent/gatekeeper#550

Signed-off-by: juliankatz <juliankatz@google.com>