### PR TITLE
Add x-preserve... to Constraint kind status

### DIFF
--- a/constraint/pkg/client/crd_helpers_test.go
+++ b/constraint/pkg/client/crd_helpers_test.go
@@ -117,6 +117,7 @@ func tProp(t string) apiextensions.JSONSchemaProps {
 
 func expectedSchema(pm propMap) *apiextensions.JSONSchemaProps {
 	pm["enforcementAction"] = apiextensions.JSONSchemaProps{Type: "string"}
+	trueBool := true
 	p := prop(
 		propMap{
 			"metadata": prop(propMap{
@@ -125,7 +126,8 @@ func expectedSchema(pm propMap) *apiextensions.JSONSchemaProps {
 					MaxLength: func(i int64) *int64 { return &i }(63),
 				},
 			}),
-			"spec": prop(pm),
+			"spec":   prop(pm),
+			"status": {XPreserveUnknownFields: &trueBool},
 		},
 	)
 	return &p


### PR DESCRIPTION
Gatekeeper adds the byPod field to the status of a Constraint once it is
applied to the cluster.  This previously relied on the preservation of
unknown fields by the API server.  As we are now applying Constraint kind
CRDs as v1 CRDs, this behavior breaks.

This PR adds an empty `status` to the Constraint kind's CRD's schema.
That status includes the `x-kubernetes-preserve-unknown-fields: true`
key/value pair, retaining the existing Gatekeeper functionality.

Contributes to open-policy-agent/gatekeeper#550

Signed-off-by: juliankatz <juliankatz@google.com>