### PR TITLE
ConstraintTemplate versions use apiextensionsv1

### DIFF
--- a/constraint/Makefile
+++ b/constraint/Makefile
@@ -60,4 +60,4 @@ generate:
 		--input-dirs "./pkg/apis/templates/..." \
 		--go-header-file=./hack/boilerplate.go.txt \
 		--output-file-base=zz_generated.conversion \
-		--extra-dirs=k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1
+		--extra-dirs=k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1

--- a/constraint/pkg/apis/templates/transform.go
+++ b/constraint/pkg/apis/templates/transform.go
@@ -18,13 +18,13 @@ package templates
 import (
 	"fmt"
 
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
-// AddPreserveUnknownFields recurses through an *apiextensionsv1beta1.JSONSchemaProps
+// AddPreserveUnknownFields recurses through an *apiextensionsv1.JSONSchemaProps
 // data structure, adding `x-kubernetes-preserve-unknown-fields: true` at every level
 // that type is equal to "object", "array", or is undefined.
-func AddPreserveUnknownFields(sch *apiextensionsv1beta1.JSONSchemaProps) error {
+func AddPreserveUnknownFields(sch *apiextensionsv1.JSONSchemaProps) error {
 	switch sch.Type {
 	// An object can have values not described in the schema.  A blank Type could be anything,
 	// including an object, so we add x-kubernetes-preserve-unknown-fields: true to both.
@@ -37,8 +37,8 @@ func AddPreserveUnknownFields(sch *apiextensionsv1beta1.JSONSchemaProps) error {
 		// this structural item schema requirement.
 		if sch.Items == nil || (sch.Items.Schema == nil && sch.Items.JSONSchemas == nil) {
 			tr := true
-			sch.Items = &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-				Schema: &apiextensionsv1beta1.JSONSchemaProps{
+			sch.Items = &apiextensionsv1.JSONSchemaPropsOrArray{
+				Schema: &apiextensionsv1.JSONSchemaProps{
 					XPreserveUnknownFields: &tr,
 				},
 			}

--- a/constraint/pkg/apis/templates/transform_test.go
+++ b/constraint/pkg/apis/templates/transform_test.go
@@ -20,62 +20,62 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
 func TestAddPreserveUnknownFields(t *testing.T) {
 	trueBool := true
 	testCases := []struct {
 		name  string
-		v     *apiextensionsv1beta1.JSONSchemaProps
-		exp   *apiextensionsv1beta1.JSONSchemaProps
+		v     *apiextensionsv1.JSONSchemaProps
+		exp   *apiextensionsv1.JSONSchemaProps
 		error bool
 	}{
 		{
 			name: "no information",
-			v:    &apiextensionsv1beta1.JSONSchemaProps{},
-			exp: &apiextensionsv1beta1.JSONSchemaProps{
+			v:    &apiextensionsv1.JSONSchemaProps{},
+			exp: &apiextensionsv1.JSONSchemaProps{
 				XPreserveUnknownFields: &trueBool,
 			},
 		},
 		{
 			name: "nil properties",
-			v: &apiextensionsv1beta1.JSONSchemaProps{
+			v: &apiextensionsv1.JSONSchemaProps{
 				Properties: nil,
 			},
-			exp: &apiextensionsv1beta1.JSONSchemaProps{
+			exp: &apiextensionsv1.JSONSchemaProps{
 				XPreserveUnknownFields: &trueBool,
 				Properties:             nil,
 			},
 		},
 		{
 			name: "x-kubernetes-preserve-unknown-fields is present already and true",
-			v: &apiextensionsv1beta1.JSONSchemaProps{
+			v: &apiextensionsv1.JSONSchemaProps{
 				XPreserveUnknownFields: &trueBool,
 			},
-			exp: &apiextensionsv1beta1.JSONSchemaProps{
+			exp: &apiextensionsv1.JSONSchemaProps{
 				XPreserveUnknownFields: &trueBool,
 			},
 		},
 		{
 			name: "type object with no Properties",
-			v: &apiextensionsv1beta1.JSONSchemaProps{
+			v: &apiextensionsv1.JSONSchemaProps{
 				Type: "object",
 			},
-			exp: &apiextensionsv1beta1.JSONSchemaProps{
+			exp: &apiextensionsv1.JSONSchemaProps{
 				XPreserveUnknownFields: &trueBool,
 				Type:                   "object",
 			},
 		},
 		{
 			name: "type array with no Items",
-			v: &apiextensionsv1beta1.JSONSchemaProps{
+			v: &apiextensionsv1.JSONSchemaProps{
 				Type: "array",
 			},
-			exp: &apiextensionsv1beta1.JSONSchemaProps{
+			exp: &apiextensionsv1.JSONSchemaProps{
 				Type: "array",
-				Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-					Schema: &apiextensionsv1beta1.JSONSchemaProps{
+				Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+					Schema: &apiextensionsv1.JSONSchemaProps{
 						XPreserveUnknownFields: &trueBool,
 					},
 				},
@@ -83,14 +83,14 @@ func TestAddPreserveUnknownFields(t *testing.T) {
 		},
 		{
 			name: "type array with Items but no schemas",
-			v: &apiextensionsv1beta1.JSONSchemaProps{
+			v: &apiextensionsv1.JSONSchemaProps{
 				Type:  "array",
-				Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{},
+				Items: &apiextensionsv1.JSONSchemaPropsOrArray{},
 			},
-			exp: &apiextensionsv1beta1.JSONSchemaProps{
+			exp: &apiextensionsv1.JSONSchemaProps{
 				Type: "array",
-				Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-					Schema: &apiextensionsv1beta1.JSONSchemaProps{
+				Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+					Schema: &apiextensionsv1.JSONSchemaProps{
 						XPreserveUnknownFields: &trueBool,
 					},
 				},
@@ -98,14 +98,14 @@ func TestAddPreserveUnknownFields(t *testing.T) {
 		},
 		{
 			name: "map with empty JSONSchemaProps value",
-			v: &apiextensionsv1beta1.JSONSchemaProps{
-				Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+			v: &apiextensionsv1.JSONSchemaProps{
+				Properties: map[string]apiextensionsv1.JSONSchemaProps{
 					"foo": {},
 				},
 			},
-			exp: &apiextensionsv1beta1.JSONSchemaProps{
+			exp: &apiextensionsv1.JSONSchemaProps{
 				XPreserveUnknownFields: &trueBool,
-				Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+				Properties: map[string]apiextensionsv1.JSONSchemaProps{
 					"foo": {
 						XPreserveUnknownFields: &trueBool,
 					},
@@ -114,24 +114,24 @@ func TestAddPreserveUnknownFields(t *testing.T) {
 		},
 		{
 			name: "Items with no type: array",
-			v: &apiextensionsv1beta1.JSONSchemaProps{
-				Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-					Schema: &apiextensionsv1beta1.JSONSchemaProps{
+			v: &apiextensionsv1.JSONSchemaProps{
+				Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+					Schema: &apiextensionsv1.JSONSchemaProps{
 						Type: "object",
-						Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+						Properties: map[string]apiextensionsv1.JSONSchemaProps{
 							"key":          {Type: "string"},
 							"allowedRegex": {Type: "string"},
 						},
 					},
 				},
 			},
-			exp: &apiextensionsv1beta1.JSONSchemaProps{
+			exp: &apiextensionsv1.JSONSchemaProps{
 				XPreserveUnknownFields: &trueBool,
-				Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-					Schema: &apiextensionsv1beta1.JSONSchemaProps{
+				Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+					Schema: &apiextensionsv1.JSONSchemaProps{
 						Type:                   "object",
 						XPreserveUnknownFields: &trueBool,
-						Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+						Properties: map[string]apiextensionsv1.JSONSchemaProps{
 							"key":          {Type: "string"},
 							"allowedRegex": {Type: "string"},
 						},
@@ -141,12 +141,12 @@ func TestAddPreserveUnknownFields(t *testing.T) {
 		},
 		{
 			name: "Recuse through doubly-nested properties",
-			v: &apiextensionsv1beta1.JSONSchemaProps{
+			v: &apiextensionsv1.JSONSchemaProps{
 				Type: "object",
-				Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+				Properties: map[string]apiextensionsv1.JSONSchemaProps{
 					"foo": {
 						Type: "object",
-						Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+						Properties: map[string]apiextensionsv1.JSONSchemaProps{
 							"bar": {
 								Type: "string",
 							},
@@ -154,14 +154,14 @@ func TestAddPreserveUnknownFields(t *testing.T) {
 					},
 				},
 			},
-			exp: &apiextensionsv1beta1.JSONSchemaProps{
+			exp: &apiextensionsv1.JSONSchemaProps{
 				Type:                   "object",
 				XPreserveUnknownFields: &trueBool,
-				Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+				Properties: map[string]apiextensionsv1.JSONSchemaProps{
 					"foo": {
 						Type:                   "object",
 						XPreserveUnknownFields: &trueBool,
-						Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+						Properties: map[string]apiextensionsv1.JSONSchemaProps{
 							"bar": {
 								Type: "string",
 							},
@@ -172,15 +172,15 @@ func TestAddPreserveUnknownFields(t *testing.T) {
 		},
 		{
 			name: "Recurse through triply-nested properties",
-			v: &apiextensionsv1beta1.JSONSchemaProps{
+			v: &apiextensionsv1.JSONSchemaProps{
 				Type: "object",
-				Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+				Properties: map[string]apiextensionsv1.JSONSchemaProps{
 					"foo": {
 						Type: "object",
-						Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+						Properties: map[string]apiextensionsv1.JSONSchemaProps{
 							"bar": {
 								Type: "object",
-								Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+								Properties: map[string]apiextensionsv1.JSONSchemaProps{
 									"burrito": {
 										Type: "string",
 									},
@@ -190,18 +190,18 @@ func TestAddPreserveUnknownFields(t *testing.T) {
 					},
 				},
 			},
-			exp: &apiextensionsv1beta1.JSONSchemaProps{
+			exp: &apiextensionsv1.JSONSchemaProps{
 				Type:                   "object",
 				XPreserveUnknownFields: &trueBool,
-				Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+				Properties: map[string]apiextensionsv1.JSONSchemaProps{
 					"foo": {
 						Type:                   "object",
 						XPreserveUnknownFields: &trueBool,
-						Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+						Properties: map[string]apiextensionsv1.JSONSchemaProps{
 							"bar": {
 								Type:                   "object",
 								XPreserveUnknownFields: &trueBool,
-								Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+								Properties: map[string]apiextensionsv1.JSONSchemaProps{
 									"burrito": {
 										Type: "string",
 									},
@@ -214,24 +214,24 @@ func TestAddPreserveUnknownFields(t *testing.T) {
 		},
 		{
 			name: "Recurse through doubly-nested Items with no type information",
-			v: &apiextensionsv1beta1.JSONSchemaProps{
-				Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-					Schema: &apiextensionsv1beta1.JSONSchemaProps{
-						Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-							Schema: &apiextensionsv1beta1.JSONSchemaProps{
+			v: &apiextensionsv1.JSONSchemaProps{
+				Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+					Schema: &apiextensionsv1.JSONSchemaProps{
+						Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+							Schema: &apiextensionsv1.JSONSchemaProps{
 								Type: "string",
 							},
 						},
 					},
 				},
 			},
-			exp: &apiextensionsv1beta1.JSONSchemaProps{
+			exp: &apiextensionsv1.JSONSchemaProps{
 				XPreserveUnknownFields: &trueBool,
-				Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-					Schema: &apiextensionsv1beta1.JSONSchemaProps{
+				Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+					Schema: &apiextensionsv1.JSONSchemaProps{
 						XPreserveUnknownFields: &trueBool,
-						Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-							Schema: &apiextensionsv1beta1.JSONSchemaProps{
+						Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+							Schema: &apiextensionsv1.JSONSchemaProps{
 								Type: "string",
 							},
 						},
@@ -241,26 +241,26 @@ func TestAddPreserveUnknownFields(t *testing.T) {
 		},
 		{
 			name: "Recurse through doubly-nested Items with array type",
-			v: &apiextensionsv1beta1.JSONSchemaProps{
+			v: &apiextensionsv1.JSONSchemaProps{
 				Type: "array",
-				Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-					Schema: &apiextensionsv1beta1.JSONSchemaProps{
+				Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+					Schema: &apiextensionsv1.JSONSchemaProps{
 						Type: "array",
-						Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-							Schema: &apiextensionsv1beta1.JSONSchemaProps{
+						Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+							Schema: &apiextensionsv1.JSONSchemaProps{
 								Type: "string",
 							},
 						},
 					},
 				},
 			},
-			exp: &apiextensionsv1beta1.JSONSchemaProps{
+			exp: &apiextensionsv1.JSONSchemaProps{
 				Type: "array",
-				Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-					Schema: &apiextensionsv1beta1.JSONSchemaProps{
+				Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+					Schema: &apiextensionsv1.JSONSchemaProps{
 						Type: "array",
-						Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-							Schema: &apiextensionsv1beta1.JSONSchemaProps{
+						Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+							Schema: &apiextensionsv1.JSONSchemaProps{
 								Type: "string",
 							},
 						},
@@ -270,21 +270,21 @@ func TestAddPreserveUnknownFields(t *testing.T) {
 		},
 		{
 			name: "Recurse through doubly-nested AdditionalProperties",
-			v: &apiextensionsv1beta1.JSONSchemaProps{
-				AdditionalProperties: &apiextensionsv1beta1.JSONSchemaPropsOrBool{
-					Schema: &apiextensionsv1beta1.JSONSchemaProps{
-						AdditionalProperties: &apiextensionsv1beta1.JSONSchemaPropsOrBool{
+			v: &apiextensionsv1.JSONSchemaProps{
+				AdditionalProperties: &apiextensionsv1.JSONSchemaPropsOrBool{
+					Schema: &apiextensionsv1.JSONSchemaProps{
+						AdditionalProperties: &apiextensionsv1.JSONSchemaPropsOrBool{
 							Allows: false,
 						},
 					},
 				},
 			},
-			exp: &apiextensionsv1beta1.JSONSchemaProps{
+			exp: &apiextensionsv1.JSONSchemaProps{
 				XPreserveUnknownFields: &trueBool,
-				AdditionalProperties: &apiextensionsv1beta1.JSONSchemaPropsOrBool{
-					Schema: &apiextensionsv1beta1.JSONSchemaProps{
+				AdditionalProperties: &apiextensionsv1.JSONSchemaPropsOrBool{
+					Schema: &apiextensionsv1.JSONSchemaProps{
 						XPreserveUnknownFields: &trueBool,
-						AdditionalProperties: &apiextensionsv1beta1.JSONSchemaPropsOrBool{
+						AdditionalProperties: &apiextensionsv1.JSONSchemaPropsOrBool{
 							Allows: false,
 						},
 					},
@@ -293,9 +293,9 @@ func TestAddPreserveUnknownFields(t *testing.T) {
 		},
 		{
 			name: "JSONSchemas not supported",
-			v: &apiextensionsv1beta1.JSONSchemaProps{
-				Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-					JSONSchemas: []apiextensionsv1beta1.JSONSchemaProps{},
+			v: &apiextensionsv1.JSONSchemaProps{
+				Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+					JSONSchemas: []apiextensionsv1.JSONSchemaProps{},
 				},
 			},
 			error: true,

--- a/constraint/pkg/apis/templates/v1alpha1/constrainttemplate_types.go
+++ b/constraint/pkg/apis/templates/v1alpha1/constrainttemplate_types.go
@@ -16,7 +16,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -47,7 +47,7 @@ type Validation struct {
 	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:validation:Type=object
 	// +kubebuilder:pruning:PreserveUnknownFields
-	OpenAPIV3Schema *apiextensionsv1beta1.JSONSchemaProps `json:"openAPIV3Schema,omitempty"`
+	OpenAPIV3Schema *apiextensionsv1.JSONSchemaProps `json:"openAPIV3Schema,omitempty"`
 }
 
 type Target struct {

--- a/constraint/pkg/apis/templates/v1alpha1/constrainttemplate_types_test.go
+++ b/constraint/pkg/apis/templates/v1alpha1/constrainttemplate_types_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/open-policy-agent/frameworks/constraint/pkg/core/templates"
 	"golang.org/x/net/context"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -82,17 +82,17 @@ func TestTypeConversion(t *testing.T) {
 						ShortNames: []string{"mhmc"},
 					},
 					Validation: &Validation{
-						OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{
-							Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Properties: map[string]apiextensionsv1.JSONSchemaProps{
 								"message": {
 									Type: "string",
 								},
 								"labels": {
 									Type: "array",
-									Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-										Schema: &apiextensionsv1beta1.JSONSchemaProps{
+									Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+										Schema: &apiextensionsv1.JSONSchemaProps{
 											Type: "object",
-											Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+											Properties: map[string]apiextensionsv1.JSONSchemaProps{
 												"key":          {Type: "string"},
 												"allowedRegex": {Type: "string"},
 											},
@@ -141,17 +141,17 @@ func TestValidationVersionConversionAndTransformation(t *testing.T) {
 		{
 			name: "Two deep properties",
 			v: &Validation{
-				OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{
-					Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+				OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+					Properties: map[string]apiextensionsv1.JSONSchemaProps{
 						"message": {
 							Type: "string",
 						},
 						"labels": {
 							Type: "array",
-							Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-								Schema: &apiextensionsv1beta1.JSONSchemaProps{
+							Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+								Schema: &apiextensionsv1.JSONSchemaProps{
 									Type: "object",
-									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+									Properties: map[string]apiextensionsv1.JSONSchemaProps{
 										"key":          {Type: "string"},
 										"allowedRegex": {Type: "string"},
 									},

--- a/constraint/pkg/apis/templates/v1alpha1/conversion.go
+++ b/constraint/pkg/apis/templates/v1alpha1/conversion.go
@@ -19,7 +19,7 @@ import (
 	apisTemplates "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates"
 	coreTemplates "github.com/open-policy-agent/frameworks/constraint/pkg/core/templates"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/conversion"
 )
 
@@ -31,7 +31,7 @@ func Convert_v1alpha1_Validation_To_templates_Validation(in *Validation, out *co
 		}
 
 		out.OpenAPIV3Schema = new(apiextensions.JSONSchemaProps)
-		if err := apiextensionsv1beta1.Convert_v1beta1_JSONSchemaProps_To_apiextensions_JSONSchemaProps(inSchema, out.OpenAPIV3Schema, s); err != nil {
+		if err := apiextensionsv1.Convert_v1_JSONSchemaProps_To_apiextensions_JSONSchemaProps(inSchema, out.OpenAPIV3Schema, s); err != nil {
 			return err
 		}
 

--- a/constraint/pkg/apis/templates/v1alpha1/zz_generated.conversion.go
+++ b/constraint/pkg/apis/templates/v1alpha1/zz_generated.conversion.go
@@ -22,7 +22,7 @@ import (
 	unsafe "unsafe"
 
 	templates "github.com/open-policy-agent/frameworks/constraint/pkg/core/templates"
-	v1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -432,8 +432,8 @@ func Convert_templates_Target_To_v1alpha1_Target(in *templates.Target, out *Targ
 func autoConvert_templates_Validation_To_v1alpha1_Validation(in *templates.Validation, out *Validation, s conversion.Scope) error {
 	if in.OpenAPIV3Schema != nil {
 		in, out := &in.OpenAPIV3Schema, &out.OpenAPIV3Schema
-		*out = new(v1beta1.JSONSchemaProps)
-		if err := v1beta1.Convert_apiextensions_JSONSchemaProps_To_v1beta1_JSONSchemaProps(*in, *out, s); err != nil {
+		*out = new(v1.JSONSchemaProps)
+		if err := v1.Convert_apiextensions_JSONSchemaProps_To_v1_JSONSchemaProps(*in, *out, s); err != nil {
 			return err
 		}
 	} else {

--- a/constraint/pkg/apis/templates/v1beta1/constrainttemplate_types.go
+++ b/constraint/pkg/apis/templates/v1beta1/constrainttemplate_types.go
@@ -16,7 +16,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -47,7 +47,7 @@ type Validation struct {
 	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:validation:Type=object
 	// +kubebuilder:pruning:PreserveUnknownFields
-	OpenAPIV3Schema *apiextensionsv1beta1.JSONSchemaProps `json:"openAPIV3Schema,omitempty"`
+	OpenAPIV3Schema *apiextensionsv1.JSONSchemaProps `json:"openAPIV3Schema,omitempty"`
 }
 
 type Target struct {

--- a/constraint/pkg/apis/templates/v1beta1/constrainttemplate_types_test.go
+++ b/constraint/pkg/apis/templates/v1beta1/constrainttemplate_types_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/open-policy-agent/frameworks/constraint/pkg/core/templates"
 	"golang.org/x/net/context"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -81,17 +81,17 @@ func TestTypeConversion(t *testing.T) {
 						ShortNames: []string{"mhmc"},
 					},
 					Validation: &Validation{
-						OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{
-							Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Properties: map[string]apiextensionsv1.JSONSchemaProps{
 								"message": {
 									Type: "string",
 								},
 								"labels": {
 									Type: "array",
-									Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-										Schema: &apiextensionsv1beta1.JSONSchemaProps{
+									Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+										Schema: &apiextensionsv1.JSONSchemaProps{
 											Type: "object",
-											Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+											Properties: map[string]apiextensionsv1.JSONSchemaProps{
 												"key":          {Type: "string"},
 												"allowedRegex": {Type: "string"},
 											},
@@ -140,17 +140,17 @@ func TestValidationVersionConversionAndTransformation(t *testing.T) {
 		{
 			name: "Two deep properties",
 			v: &Validation{
-				OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{
-					Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+				OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+					Properties: map[string]apiextensionsv1.JSONSchemaProps{
 						"message": {
 							Type: "string",
 						},
 						"labels": {
 							Type: "array",
-							Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-								Schema: &apiextensionsv1beta1.JSONSchemaProps{
+							Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+								Schema: &apiextensionsv1.JSONSchemaProps{
 									Type: "object",
-									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+									Properties: map[string]apiextensionsv1.JSONSchemaProps{
 										"key":          {Type: "string"},
 										"allowedRegex": {Type: "string"},
 									},

--- a/constraint/pkg/apis/templates/v1beta1/conversion.go
+++ b/constraint/pkg/apis/templates/v1beta1/conversion.go
@@ -19,7 +19,7 @@ import (
 	apisTemplates "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates"
 	coreTemplates "github.com/open-policy-agent/frameworks/constraint/pkg/core/templates"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/conversion"
 )
 
@@ -31,7 +31,7 @@ func Convert_v1beta1_Validation_To_templates_Validation(in *Validation, out *cor
 		}
 
 		out.OpenAPIV3Schema = new(apiextensions.JSONSchemaProps)
-		if err := apiextensionsv1beta1.Convert_v1beta1_JSONSchemaProps_To_apiextensions_JSONSchemaProps(inSchemaCopy, out.OpenAPIV3Schema, s); err != nil {
+		if err := apiextensionsv1.Convert_v1_JSONSchemaProps_To_apiextensions_JSONSchemaProps(inSchemaCopy, out.OpenAPIV3Schema, s); err != nil {
 			return err
 		}
 	} else {

--- a/constraint/pkg/apis/templates/v1beta1/zz_generated.conversion.go
+++ b/constraint/pkg/apis/templates/v1beta1/zz_generated.conversion.go
@@ -22,7 +22,7 @@ import (
 	unsafe "unsafe"
 
 	templates "github.com/open-policy-agent/frameworks/constraint/pkg/core/templates"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -432,8 +432,8 @@ func Convert_templates_Target_To_v1beta1_Target(in *templates.Target, out *Targe
 func autoConvert_templates_Validation_To_v1beta1_Validation(in *templates.Validation, out *Validation, s conversion.Scope) error {
 	if in.OpenAPIV3Schema != nil {
 		in, out := &in.OpenAPIV3Schema, &out.OpenAPIV3Schema
-		*out = new(apiextensionsv1beta1.JSONSchemaProps)
-		if err := apiextensionsv1beta1.Convert_apiextensions_JSONSchemaProps_To_v1beta1_JSONSchemaProps(*in, *out, s); err != nil {
+		*out = new(v1.JSONSchemaProps)
+		if err := v1.Convert_apiextensions_JSONSchemaProps_To_v1_JSONSchemaProps(*in, *out, s); err != nil {
 			return err
 		}
 	} else {


### PR DESCRIPTION
Previously, I left ConstraintTemplate (CT) versions v1alpha1 and v1beta1
using apiextensionsv1beta1.JSONSchemaProps.  I thought this appropriate,
given that was what they were previously implemented as.  v1 CT, on the
other hand, would use v1beta1 JSONSchemaProps.

This turns out to be a bad idea.

Any logic we write that interacts with OpenAPIV3Schema in a CT's
Validation section is forced to interact with OpenAPIV3Schema's type.
Before this PR, that type is apiextensionsv1beta1.JSONSchemaProps.  This
makes our life difficult, as v1 CT's version of this variable will have
a different type.  This would then require us to re-implement any logic
for this section to implement a second type, or to do some gross
conversions.

Further, apiextensionsv1beta1 will be removed from
k8s.io/apiextensions-apiserver, preventing us from upgrading that
library without doing this work.

Basically, this change is unavoidable and appropriate.

This blocks open-policy-agent/frameworks#121

Contributes to open-policy-agent/gatekeeper#550

Signed-off-by: juliankatz <juliankatz@google.com>