### PR TITLE
Set PreserveUnknownFields: false in v1 CRDs

### DIFF
--- a/constraint/Makefile
+++ b/constraint/Makefile
@@ -40,7 +40,7 @@ manifests:
 		crd:allowDangerousTypes="true" \
 		paths="./pkg/..." \
 		output:crd:artifacts:config=config/crds
-	cp config/crds/* deploy/crds.yaml
+	kustomize build config/crds --output=deploy/crds.yaml
 
 lint:
 	golangci-lint -v run ./... --timeout 5m

--- a/constraint/config/crds/kustomization.yaml
+++ b/constraint/config/crds/kustomization.yaml
@@ -8,4 +8,4 @@ patchesStrategicMerge:
   metadata:
     name: constrainttemplates.templates.gatekeeper.sh
   spec:
-    PreserveUnknownFields: false
+    preserveUnknownFields: false

--- a/constraint/config/crds/kustomization.yaml
+++ b/constraint/config/crds/kustomization.yaml
@@ -1,0 +1,11 @@
+resources:
+- templates.gatekeeper.sh_constrainttemplates.yaml
+
+patchesStrategicMerge:
+- |-
+  apiVersion: apiextensions.k8s.io/v1
+  kind: CustomResourceDefinition
+  metadata:
+    name: constrainttemplates.templates.gatekeeper.sh
+  spec:
+    PreserveUnknownFields: false

--- a/constraint/deploy/crds.yaml
+++ b/constraint/deploy/crds.yaml
@@ -1,13 +1,11 @@
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.5.0
-  creationTimestamp: null
   name: constrainttemplates.templates.gatekeeper.sh
 spec:
+  PreserveUnknownFields: false
   group: templates.gatekeeper.sh
   names:
     kind: ConstraintTemplate
@@ -19,18 +17,13 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ConstraintTemplate is the Schema for the constrainttemplates
-          API
+        description: ConstraintTemplate is the Schema for the constrainttemplates API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -77,13 +70,11 @@ spec:
             properties:
               byPod:
                 items:
-                  description: ByPodStatus defines the observed state of ConstraintTemplate
-                    as seen by an individual controller
+                  description: ByPodStatus defines the observed state of ConstraintTemplate as seen by an individual controller
                   properties:
                     errors:
                       items:
-                        description: CreateCRDError represents a single error caught
-                          during parsing, compiling, etc.
+                        description: CreateCRDError represents a single error caught during parsing, compiling, etc.
                         properties:
                           code:
                             type: string
@@ -97,8 +88,7 @@ spec:
                         type: object
                       type: array
                     id:
-                      description: a unique identifier for the pod that wrote the
-                        status
+                      description: a unique identifier for the pod that wrote the status
                       type: string
                     observedGeneration:
                       format: int64
@@ -117,18 +107,13 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: ConstraintTemplate is the Schema for the constrainttemplates
-          API
+        description: ConstraintTemplate is the Schema for the constrainttemplates API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -175,13 +160,11 @@ spec:
             properties:
               byPod:
                 items:
-                  description: ByPodStatus defines the observed state of ConstraintTemplate
-                    as seen by an individual controller
+                  description: ByPodStatus defines the observed state of ConstraintTemplate as seen by an individual controller
                   properties:
                     errors:
                       items:
-                        description: CreateCRDError represents a single error caught
-                          during parsing, compiling, etc.
+                        description: CreateCRDError represents a single error caught during parsing, compiling, etc.
                         properties:
                           code:
                             type: string
@@ -195,8 +178,7 @@ spec:
                         type: object
                       type: array
                     id:
-                      description: a unique identifier for the pod that wrote the
-                        status
+                      description: a unique identifier for the pod that wrote the status
                       type: string
                     observedGeneration:
                       format: int64

--- a/constraint/deploy/crds.yaml
+++ b/constraint/deploy/crds.yaml
@@ -5,13 +5,13 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.5.0
   name: constrainttemplates.templates.gatekeeper.sh
 spec:
-  PreserveUnknownFields: false
   group: templates.gatekeeper.sh
   names:
     kind: ConstraintTemplate
     listKind: ConstraintTemplateList
     plural: constrainttemplates
     singular: constrainttemplate
+  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1alpha1

--- a/constraint/pkg/client/crd_helpers.go
+++ b/constraint/pkg/client/crd_helpers.go
@@ -92,9 +92,11 @@ func newCRDHelper() (*crdHelper, error) {
 func (h *crdHelper) createCRD(
 	templ *templates.ConstraintTemplate,
 	schema *apiextensions.JSONSchemaProps) (*apiextensions.CustomResourceDefinition, error) {
+	falseBool := false
 	crd := &apiextensions.CustomResourceDefinition{
 		Spec: apiextensions.CustomResourceDefinitionSpec{
-			Group: constraintGroup,
+			PreserveUnknownFields: &falseBool,
+			Group:                 constraintGroup,
 			Names: apiextensions.CustomResourceDefinitionNames{
 				Kind:       templ.Spec.CRD.Spec.Names.Kind,
 				ListKind:   templ.Spec.CRD.Spec.Names.Kind + "List",


### PR DESCRIPTION
Our CRDs were previously of version v1beta1.  In v1beta1,
spec.PreserveUnknownFields defaulted to `true`.  As we did not set this
value explicitly, the value was set to `true`.

We've now updated our CRDs to v1.  In v1, spec.PreserveUnknownFields
defaults to false.  In fact, it is being deprecated in favor of the more
targeted x-kubernetes-preserve-unknown-fields field.

Despite this new default, spec.PreserveUnknownFields remains `true` for
our CRDs, even after applying the new v1 versions.  This does not cause
any bad behavior, but is incorrect.  The simple fix is to set
spec.PreserveUnknownFields to false in all our CRDs.

As the Constraint kind CRD is generated in code, I've added this field
in constraint/pkg/client/crd_helpers.go.

The ConstraintTemplate CRD is generated using `controller-gen`, but 
v0.5.0 of the tool doesn't include an annotation for that, presumably
because it's not longer the supported path for disabling pruning.  So, I've
achieved the desired effect with a simple kustomize patch.

Contributes to open-policy-agent/gatekeeper#550

Signed-off-by: juliankatz <juliankatz@google.com>