### PR TITLE
Use git lfs for large dependencies

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+constraint/vendor/github.com/bytecodealliance/wasmtime-go/build/linux-x86_64/libwasmtime.a filter=lfs diff=lfs merge=lfs -text
+constraint/vendor/github.com/bytecodealliance/wasmtime-go/build/macos-x86_64/libwasmtime.a filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
This will prevent unnecessarily copying the large files unless needed, and get rid of the warning any time we run "git push" or similar.

Signed-off-by: Will Beason <willbeason@google.com>