### PR TITLE
Inject empty `parameters` field for legacy schemas

### DIFF
--- a/constraint/config/crds/templates.gatekeeper.sh_constrainttemplates.yaml
+++ b/constraint/config/crds/templates.gatekeeper.sh_constrainttemplates.yaml
@@ -19,18 +19,13 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: ConstraintTemplate is the Schema for the constrainttemplates
-          API
+        description: ConstraintTemplate is the Schema for the constrainttemplates API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -51,6 +46,8 @@ spec:
                             type: array
                         type: object
                       validation:
+                        default:
+                          legacySchema: false
                         properties:
                           legacySchema:
                             default: false
@@ -80,13 +77,11 @@ spec:
             properties:
               byPod:
                 items:
-                  description: ByPodStatus defines the observed state of ConstraintTemplate
-                    as seen by an individual controller
+                  description: ByPodStatus defines the observed state of ConstraintTemplate as seen by an individual controller
                   properties:
                     errors:
                       items:
-                        description: CreateCRDError represents a single error caught
-                          during parsing, compiling, etc.
+                        description: CreateCRDError represents a single error caught during parsing, compiling, etc.
                         properties:
                           code:
                             type: string
@@ -100,8 +95,7 @@ spec:
                         type: object
                       type: array
                     id:
-                      description: a unique identifier for the pod that wrote the
-                        status
+                      description: a unique identifier for the pod that wrote the status
                       type: string
                     observedGeneration:
                       format: int64
@@ -147,6 +141,8 @@ spec:
                             type: array
                         type: object
                       validation:
+                        default:
+                          legacySchema: true
                         properties:
                           legacySchema:
                             default: true
@@ -240,6 +236,8 @@ spec:
                             type: array
                         type: object
                       validation:
+                        default:
+                          legacySchema: true
                         properties:
                           legacySchema:
                             default: true

--- a/constraint/deploy/crds.yaml
+++ b/constraint/deploy/crds.yaml
@@ -44,6 +44,8 @@ spec:
                             type: array
                         type: object
                       validation:
+                        default:
+                          legacySchema: false
                         properties:
                           legacySchema:
                             default: false
@@ -137,6 +139,8 @@ spec:
                             type: array
                         type: object
                       validation:
+                        default:
+                          legacySchema: true
                         properties:
                           legacySchema:
                             default: true
@@ -230,6 +234,8 @@ spec:
                             type: array
                         type: object
                       validation:
+                        default:
+                          legacySchema: true
                         properties:
                           legacySchema:
                             default: true

--- a/constraint/pkg/apis/templates/v1/constrainttemplate_types.go
+++ b/constraint/pkg/apis/templates/v1/constrainttemplate_types.go
@@ -34,7 +34,8 @@ type CRD struct {
 }
 
 type CRDSpec struct {
-	Names      Names       `json:"names,omitempty"`
+	Names Names `json:"names,omitempty"`
+	// +kubebuilder:default={legacySchema: false}
 	Validation *Validation `json:"validation,omitempty"`
 }
 

--- a/constraint/pkg/apis/templates/v1/constrainttemplate_types_test.go
+++ b/constraint/pkg/apis/templates/v1/constrainttemplate_types_test.go
@@ -236,6 +236,28 @@ func TestValidationVersionConversionAndTransformation(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Nil properties, LegacySchema=true",
+			v: &Validation{
+				LegacySchema:    true,
+				OpenAPIV3Schema: nil,
+			},
+			exp: &templates.Validation{
+				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
+					XPreserveUnknownFields: &trueBool,
+				},
+			},
+		},
+		{
+			name: "Nil properties, LegacySchema=false",
+			v: &Validation{
+				LegacySchema:    false,
+				OpenAPIV3Schema: nil,
+			},
+			exp: &templates.Validation{
+				OpenAPIV3Schema: nil,
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/constraint/pkg/apis/templates/v1/conversion.go
+++ b/constraint/pkg/apis/templates/v1/conversion.go
@@ -24,8 +24,14 @@ import (
 )
 
 func Convert_v1_Validation_To_templates_Validation(in *Validation, out *coreTemplates.Validation, s conversion.Scope) error { //nolint:golint
-	if in.OpenAPIV3Schema != nil {
-		inSchemaCopy := in.OpenAPIV3Schema.DeepCopy()
+	inSchema := in.OpenAPIV3Schema
+	// legacySchema should allow for users to provide arbitrary parameters, regardless of whether the user specified them
+	if in.LegacySchema && inSchema == nil {
+		inSchema = &apiextensionsv1.JSONSchemaProps{}
+	}
+
+	if inSchema != nil {
+		inSchemaCopy := inSchema.DeepCopy()
 
 		if in.LegacySchema {
 			if err := apisTemplates.AddPreserveUnknownFields(inSchemaCopy); err != nil {

--- a/constraint/pkg/apis/templates/v1alpha1/constrainttemplate_types.go
+++ b/constraint/pkg/apis/templates/v1alpha1/constrainttemplate_types.go
@@ -34,7 +34,8 @@ type CRD struct {
 }
 
 type CRDSpec struct {
-	Names      Names       `json:"names,omitempty"`
+	Names Names `json:"names,omitempty"`
+	// +kubebuilder:default={legacySchema: true}
 	Validation *Validation `json:"validation,omitempty"`
 }
 

--- a/constraint/pkg/apis/templates/v1alpha1/constrainttemplate_types_test.go
+++ b/constraint/pkg/apis/templates/v1alpha1/constrainttemplate_types_test.go
@@ -231,6 +231,28 @@ func TestValidationVersionConversionAndTransformation(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Nil properties, LegacySchema=true",
+			v: &Validation{
+				LegacySchema:    true,
+				OpenAPIV3Schema: nil,
+			},
+			exp: &templates.Validation{
+				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
+					XPreserveUnknownFields: &trueBool,
+				},
+			},
+		},
+		{
+			name: "Nil properties, LegacySchema=false",
+			v: &Validation{
+				LegacySchema:    false,
+				OpenAPIV3Schema: nil,
+			},
+			exp: &templates.Validation{
+				OpenAPIV3Schema: nil,
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/constraint/pkg/apis/templates/v1alpha1/conversion.go
+++ b/constraint/pkg/apis/templates/v1alpha1/conversion.go
@@ -24,8 +24,14 @@ import (
 )
 
 func Convert_v1alpha1_Validation_To_templates_Validation(in *Validation, out *coreTemplates.Validation, s conversion.Scope) error { //nolint:golint
-	if in.OpenAPIV3Schema != nil {
-		inSchemaCopy := in.OpenAPIV3Schema.DeepCopy()
+	inSchema := in.OpenAPIV3Schema
+	// legacySchema should allow for users to provide arbitrary parameters, regardless of whether the user specified them
+	if in.LegacySchema && inSchema == nil {
+		inSchema = &apiextensionsv1.JSONSchemaProps{}
+	}
+
+	if inSchema != nil {
+		inSchemaCopy := inSchema.DeepCopy()
 
 		if in.LegacySchema {
 			if err := apisTemplates.AddPreserveUnknownFields(inSchemaCopy); err != nil {

--- a/constraint/pkg/apis/templates/v1beta1/constrainttemplate_types.go
+++ b/constraint/pkg/apis/templates/v1beta1/constrainttemplate_types.go
@@ -34,7 +34,8 @@ type CRD struct {
 }
 
 type CRDSpec struct {
-	Names      Names       `json:"names,omitempty"`
+	Names Names `json:"names,omitempty"`
+	// +kubebuilder:default={legacySchema: true}
 	Validation *Validation `json:"validation,omitempty"`
 }
 

--- a/constraint/pkg/apis/templates/v1beta1/constrainttemplate_types_test.go
+++ b/constraint/pkg/apis/templates/v1beta1/constrainttemplate_types_test.go
@@ -230,6 +230,28 @@ func TestValidationVersionConversionAndTransformation(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Nil properties, LegacySchema=true",
+			v: &Validation{
+				LegacySchema:    true,
+				OpenAPIV3Schema: nil,
+			},
+			exp: &templates.Validation{
+				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
+					XPreserveUnknownFields: &trueBool,
+				},
+			},
+		},
+		{
+			name: "Nil properties, LegacySchema=false",
+			v: &Validation{
+				LegacySchema:    false,
+				OpenAPIV3Schema: nil,
+			},
+			exp: &templates.Validation{
+				OpenAPIV3Schema: nil,
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/constraint/pkg/apis/templates/v1beta1/conversion.go
+++ b/constraint/pkg/apis/templates/v1beta1/conversion.go
@@ -24,8 +24,14 @@ import (
 )
 
 func Convert_v1beta1_Validation_To_templates_Validation(in *Validation, out *coreTemplates.Validation, s conversion.Scope) error { //nolint:golint
-	if in.OpenAPIV3Schema != nil {
-		inSchemaCopy := in.OpenAPIV3Schema.DeepCopy()
+	inSchema := in.OpenAPIV3Schema
+	// legacySchema should allow for users to provide arbitrary parameters, regardless of whether the user specified them
+	if in.LegacySchema && inSchema == nil {
+		inSchema = &apiextensionsv1.JSONSchemaProps{}
+	}
+
+	if inSchema != nil {
+		inSchemaCopy := inSchema.DeepCopy()
 
 		if in.LegacySchema {
 			if err := apisTemplates.AddPreserveUnknownFields(inSchemaCopy); err != nil {


### PR DESCRIPTION
To handle legacy (pre-v1) CRDs, we inject
x-kubernetes-preserve-unknown-fields
in order to preserve the legacy behavior
that unknown fields were not pruned by the API
server.

Unfortunately, we are not handling the case
where no parameters are provided, which currently
means that parameters will be stripped from users' CRs.

This fixes that.

Fixes: https://github.com/open-policy-agent/gatekeeper/issues/1468

Signed-off-by: Max Smythe <smythe@google.com>