### PR TITLE
Upgrade frameworks version of golangci-lint

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -7,23 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-        with:
-          path: go/src/github.com/open-policy-agent/frameworks
-
-      - name: Install golangci-lint
-        run: |
-          mkdir -p $GITHUB_WORKSPACE/bin
-          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
-          curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $GITHUB_WORKSPACE/bin v${GOLANGCILINT_VERSION}
-        env:
-          GOLANGCILINT_VERSION: 1.32.2
-
-      - name: Make lint
-        run: |
-          make lint
-        working-directory: go/src/github.com/open-policy-agent/frameworks/constraint
+    - uses: actions/checkout@v2
+      # source: https://github.com/golangci/golangci-lint-action
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v2
+      with:
+        # version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+        version: v1.42.1
+        working-directory: constraint
 
   test:
     name: "Unit test"

--- a/constraint/.golangci.yaml
+++ b/constraint/.golangci.yaml
@@ -1,25 +1,44 @@
-linter-settings:
+run:
+  timeout: 5m
+
+linters-settings:
+  gocritic:
+    enabled-tags:
+    - performance
+  gosec:
+    excludes:
+    - G108
   lll:
     line-length: 200
 
   misspell:
     locale: US
+  staticcheck:
+    # Select the Go version to target. The default is '1.13'.
+    go: "1.17"
 
 linters:
   disable-all: true
   enable:
-    - errcheck
-    - govet
-    - ineffassign
-    - golint
-    - goconst
-    - gofmt
-    - goimports
-    - unused
-    - varcheck
-    - deadcode
-    - misspell
-    - typecheck
-    - structcheck
-    - staticcheck
-    - gosimple
+  - deadcode
+  - errcheck
+  - exportloopref
+  - forcetypeassert
+  - gocritic
+  - goconst
+  - godot
+  - gofmt
+  - gofumpt
+  - goimports
+  - gosec
+  - gosimple
+  - govet
+  - ineffassign
+  - misspell
+  - revive # replacement for golint
+  - staticcheck
+  - structcheck
+  - typecheck
+  - unused
+  - varcheck
+  - whitespace

--- a/constraint/README.md
+++ b/constraint/README.md
@@ -5,7 +5,7 @@
 ### What is a Constraint?
 
 A constraint is a declaration that its author wants a system to meet a given set of
-requirements. For example, if I have a system with objects that can be labeled and
+requirements. For example, if I have a system with objects that can be labeled, and
 I want to make sure that every object has a `billing` label, I might write the
 following constraint YAML:
 
@@ -34,7 +34,7 @@ multiple places in a workflow, improving likelihood of compliance.
 ### What is a Constraint Template?
 
 Constraint Templates allow people to declare new constraints. They can provide the
-expected input parameters and the underlying Rego necessary to enforce their
+expected input parameters, and the underlying Rego necessary to enforce their
 intent. For example, to define the `FooSystemRequiredLabel` constraint kind
 implemented above, I might write the following template YAML:
 
@@ -130,7 +130,7 @@ in the same validation context. This is probably best illustrated by a few examp
 ##### Kubernetes Admission Webhooks Create a Target
  
 All Kubernetes resources are defined by `group`, `version` and `kind`. They can
-additionally be grouped by namespace, or by using label selectors. Therefore they
+additionally be grouped by namespace, or by using label selectors. Therefore, they
 have a common naming and selection scheme. All Kubernetes resources declaratively
 configure the state of a Kubernetes cluster, therefore they share a purpose.
 Finally, they are all can be evaluated using a [Validating Admission Webhook](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/).
@@ -141,15 +141,15 @@ Kubernetes admission webhooks a potential target.
  
 All Kubernetes requests can be defined by their type (e.g. `CREATE`, `UPDATE`,
 `WATCH`) and therefore have a common selection scheme. All Kubernetes requests
-broadcast the requestor's intent to modify the Kubernetes cluster. Therefore they
+broadcast the requestor's intent to modify the Kubernetes cluster. Therefore, they
 have a common purpose. All requests can be evaluated by an [authorization webhook](https://kubernetes.io/docs/reference/access-authn-authz/webhook/)
 and therefore they share a common evaluation schema.
  
 #### How Do I Know if [X] Should be a Target?
  
-Currently there are no hard and fast litmus tests for determining a good boundary
+Currently, there are no hard and fast litmus tests for determining a good boundary
 for a target, much like there are no hard and fast rules for what should be in a
-function or a class, just guidelines, ideology and the notion of orthoganality and
+function or a class, just guidelines, ideology and the notion of orthogonality and
 testability (among others). Chances are, if you can come up with a set of rules for
 a new system that could be useful, you may have a good candidate for a new target.
 
@@ -200,10 +200,10 @@ The most interesting fields here are `HandleReview()`, `MatchSchema()`, and `Lib
 
 ### `HandleReview()`
 
-`HandleReview()` determinines whether and how a target handler is involved with a
+`HandleReview()` determines whether and how a target handler is involved with a
 `Review()` request (which checks to make sure an input complies with all
 constraints). It returns `true` if the target should be involved with reviewing the
-object and the second return value defines the schema of the `input.review` object
+object, and the second return value defines the schema of the `input.review` object
 available to all constraint rules.
 
 ### `MatchSchema()`

--- a/constraint/cmd/rewrite-compatibility/main.go
+++ b/constraint/cmd/rewrite-compatibility/main.go
@@ -82,7 +82,6 @@ func compileSrcs(
 			"data.inventory",
 		},
 	)
-
 	if err != nil {
 		return err
 	}

--- a/constraint/cmd/rewrite-compatibility/main.go
+++ b/constraint/cmd/rewrite-compatibility/main.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/golang/glog"
 	_ "github.com/golang/glog"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -67,10 +66,10 @@ func compileSrcs(
 	oldRoot string,
 	newRoot string) error {
 	if len(cts) == 0 && len(libs) == 0 {
-		return errors.Errorf("must specify --ct or --lib or both")
+		return fmt.Errorf("must specify --ct or --lib or both")
 	}
 	if (oldRoot == "") != (newRoot == "") {
-		return errors.Errorf("--input and --output must be empty or non empty together")
+		return fmt.Errorf("--input and --output must be empty or non empty together")
 	}
 
 	regoRewriter, err := regorewriter.New(

--- a/constraint/pkg/apis/apis.go
+++ b/constraint/pkg/apis/apis.go
@@ -24,10 +24,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-// AddToSchemes may be used to add all resources defined in the project to a Scheme
+// AddToSchemes may be used to add all resources defined in the project to a Scheme.
 var AddToSchemes runtime.SchemeBuilder
 
-// AddToScheme adds all Resources to the Scheme
+// AddToScheme adds all Resources to the Scheme.
 func AddToScheme(s *runtime.Scheme) error {
 	return AddToSchemes.AddToScheme(s)
 }

--- a/constraint/pkg/apis/templates/crd_schema.go
+++ b/constraint/pkg/apis/templates/crd_schema.go
@@ -9,6 +9,8 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+// ConstraintTemplateSchemas are the per-version structural schemas for
+// ConstraintTemplates.
 var ConstraintTemplateSchemas map[string]*schema.Structural
 
 func initializeCTSchemaMap() {

--- a/constraint/pkg/apis/templates/scheme.go
+++ b/constraint/pkg/apis/templates/scheme.go
@@ -6,6 +6,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+// Scheme is the global schema used for transforming Templates between API Versions.
 var Scheme *runtime.Scheme
 
 func initializeScheme() {

--- a/constraint/pkg/apis/templates/transform.go
+++ b/constraint/pkg/apis/templates/transform.go
@@ -46,7 +46,8 @@ func AddPreserveUnknownFields(sch *apiextensionsv1.JSONSchemaProps) error {
 	}
 
 	if sch.Properties != nil {
-		for k, v := range sch.Properties {
+		for k := range sch.Properties {
+			v := sch.Properties[k]
 			if err := AddPreserveUnknownFields(&v); err != nil {
 				return err
 			}

--- a/constraint/pkg/apis/templates/v1/constrainttemplate_types.go
+++ b/constraint/pkg/apis/templates/v1/constrainttemplate_types.go
@@ -23,7 +23,7 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// ConstraintTemplateSpec defines the desired state of ConstraintTemplate
+// ConstraintTemplateSpec defines the desired state of ConstraintTemplate.
 type ConstraintTemplateSpec struct {
 	CRD     CRD      `json:"crd,omitempty"`
 	Targets []Target `json:"targets,omitempty"`
@@ -76,7 +76,7 @@ type ByPodStatus struct {
 	Errors             []CreateCRDError `json:"errors,omitempty"`
 }
 
-// ConstraintTemplateStatus defines the observed state of ConstraintTemplate
+// ConstraintTemplateStatus defines the observed state of ConstraintTemplate.
 type ConstraintTemplateStatus struct {
 	Created bool          `json:"created,omitempty"`
 	ByPod   []ByPodStatus `json:"byPod,omitempty"`
@@ -104,7 +104,7 @@ type ConstraintTemplate struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// ConstraintTemplateList contains a list of ConstraintTemplate
+// ConstraintTemplateList contains a list of ConstraintTemplate.
 type ConstraintTemplateList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/constraint/pkg/apis/templates/v1/constrainttemplate_types_test.go
+++ b/constraint/pkg/apis/templates/v1/constrainttemplate_types_test.go
@@ -136,7 +136,7 @@ func TestTypeConversion(t *testing.T) {
 
 // TestValidationVersionConversionAndTransformation confirms that our custom conversion
 // function works, and also that it adds in the x-kubernetes-preserve-unknown-fields information
-// that we require for v1 CRD support
+// that we require for v1 CRD support.
 func TestValidationVersionConversionAndTransformation(t *testing.T) {
 	// The scheme is responsible for defaulting
 	scheme := runtime.NewScheme()

--- a/constraint/pkg/apis/templates/v1/conversion.go
+++ b/constraint/pkg/apis/templates/v1/conversion.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/conversion"
 )
 
-func Convert_v1_Validation_To_templates_Validation(in *Validation, out *coreTemplates.Validation, s conversion.Scope) error { //nolint:golint
+func Convert_v1_Validation_To_templates_Validation(in *Validation, out *coreTemplates.Validation, s conversion.Scope) error { // nolint:revive // Required exact function name.
 	inSchema := in.OpenAPIV3Schema
 
 	// legacySchema should allow for users to provide arbitrary parameters, regardless of whether the user specified them
@@ -44,7 +44,6 @@ func Convert_v1_Validation_To_templates_Validation(in *Validation, out *coreTemp
 		if err := apiextensionsv1.Convert_v1_JSONSchemaProps_To_apiextensions_JSONSchemaProps(inSchemaCopy, out.OpenAPIV3Schema, s); err != nil {
 			return err
 		}
-
 	} else {
 		out.OpenAPIV3Schema = nil
 	}

--- a/constraint/pkg/apis/templates/v1/defaults.go
+++ b/constraint/pkg/apis/templates/v1/defaults.go
@@ -12,7 +12,7 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 	return RegisterDefaults(scheme)
 }
 
-func SetDefaults_ConstraintTemplate(obj *ConstraintTemplate) { //nolint:golint
+func SetDefaults_ConstraintTemplate(obj *ConstraintTemplate) { // nolint:revive // Required exact function name.
 	// turn the CT into an unstructured
 	un, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
 	if err != nil {

--- a/constraint/pkg/apis/templates/v1/helpers.go
+++ b/constraint/pkg/apis/templates/v1/helpers.go
@@ -6,7 +6,7 @@ import (
 )
 
 // ToVersionless runs defaulting functions and then converts the ConstraintTemplate to the
-// versionless api representation
+// versionless api representation.
 func (versioned *ConstraintTemplate) ToVersionless() (*templates.ConstraintTemplate, error) {
 	if err := AddToScheme(apisTemplates.Scheme); err != nil {
 		return nil, err

--- a/constraint/pkg/apis/templates/v1/register.go
+++ b/constraint/pkg/apis/templates/v1/register.go
@@ -30,14 +30,15 @@ import (
 )
 
 var (
-	// SchemeGroupVersion is group version used to register these objects
+	// SchemeGroupVersion is group version used to register these objects.
 	SchemeGroupVersion = schema.GroupVersion{Group: "templates.gatekeeper.sh", Version: "v1"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: SchemeGroupVersion}
 
 	localSchemeBuilder = runtime.NewSchemeBuilder(SchemeBuilder.AddToScheme, addDefaultingFuncs)
 
+	// AddToScheme adds templates/v1 types to a Scheme.
 	AddToScheme = localSchemeBuilder.AddToScheme
 )
 

--- a/constraint/pkg/apis/templates/v1/v1_suite_test.go
+++ b/constraint/pkg/apis/templates/v1/v1_suite_test.go
@@ -27,8 +27,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
 
-var cfg *rest.Config
-var c client.Client
+var (
+	cfg *rest.Config
+	c   client.Client
+)
 
 func TestMain(m *testing.M) {
 	t := &envtest.Environment{

--- a/constraint/pkg/apis/templates/v1alpha1/constrainttemplate_types.go
+++ b/constraint/pkg/apis/templates/v1alpha1/constrainttemplate_types.go
@@ -23,7 +23,7 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// ConstraintTemplateSpec defines the desired state of ConstraintTemplate
+// ConstraintTemplateSpec defines the desired state of ConstraintTemplate.
 type ConstraintTemplateSpec struct {
 	CRD     CRD      `json:"crd,omitempty"`
 	Targets []Target `json:"targets,omitempty"`
@@ -76,7 +76,7 @@ type ByPodStatus struct {
 	Errors             []CreateCRDError `json:"errors,omitempty"`
 }
 
-// ConstraintTemplateStatus defines the observed state of ConstraintTemplate
+// ConstraintTemplateStatus defines the observed state of ConstraintTemplate.
 type ConstraintTemplateStatus struct {
 	Created bool          `json:"created,omitempty"`
 	ByPod   []ByPodStatus `json:"byPod,omitempty"`
@@ -102,7 +102,7 @@ type ConstraintTemplate struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// ConstraintTemplateList contains a list of ConstraintTemplate
+// ConstraintTemplateList contains a list of ConstraintTemplate.
 type ConstraintTemplateList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/constraint/pkg/apis/templates/v1alpha1/constrainttemplate_types_test.go
+++ b/constraint/pkg/apis/templates/v1alpha1/constrainttemplate_types_test.go
@@ -131,7 +131,7 @@ func TestTypeConversion(t *testing.T) {
 
 // TestValidationVersionConversionAndTransformation confirms that our custom conversion
 // function works, and also that it adds in the x-kubernetes-preserve-unknown-fields information
-// that we require for v1 CRD support
+// that we require for v1 CRD support.
 func TestValidationVersionConversionAndTransformation(t *testing.T) {
 	// The scheme is responsible for defaulting
 	scheme := runtime.NewScheme()

--- a/constraint/pkg/apis/templates/v1alpha1/conversion.go
+++ b/constraint/pkg/apis/templates/v1alpha1/conversion.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/conversion"
 )
 
-func Convert_v1alpha1_Validation_To_templates_Validation(in *Validation, out *coreTemplates.Validation, s conversion.Scope) error { //nolint:golint
+func Convert_v1alpha1_Validation_To_templates_Validation(in *Validation, out *coreTemplates.Validation, s conversion.Scope) error { // nolint:revive // Required exact function name.
 	inSchema := in.OpenAPIV3Schema
 
 	// legacySchema should allow for users to provide arbitrary parameters, regardless of whether the user specified them
@@ -44,7 +44,6 @@ func Convert_v1alpha1_Validation_To_templates_Validation(in *Validation, out *co
 		if err := apiextensionsv1.Convert_v1_JSONSchemaProps_To_apiextensions_JSONSchemaProps(inSchemaCopy, out.OpenAPIV3Schema, s); err != nil {
 			return err
 		}
-
 	} else {
 		out.OpenAPIV3Schema = nil
 	}

--- a/constraint/pkg/apis/templates/v1alpha1/defaults.go
+++ b/constraint/pkg/apis/templates/v1alpha1/defaults.go
@@ -12,7 +12,7 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 	return RegisterDefaults(scheme)
 }
 
-func SetDefaults_ConstraintTemplate(obj *ConstraintTemplate) { //nolint:golint
+func SetDefaults_ConstraintTemplate(obj *ConstraintTemplate) { // nolint:revive // Required exact function name.
 	// turn the CT into an unstructured
 	un, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
 	if err != nil {

--- a/constraint/pkg/apis/templates/v1alpha1/helpers.go
+++ b/constraint/pkg/apis/templates/v1alpha1/helpers.go
@@ -6,7 +6,7 @@ import (
 )
 
 // ToVersionless runs defaulting functions and then converts the ConstraintTemplate to the
-// versionless api representation
+// versionless api representation.
 func (versioned *ConstraintTemplate) ToVersionless() (*templates.ConstraintTemplate, error) {
 	if err := AddToScheme(apisTemplates.Scheme); err != nil {
 		return nil, err

--- a/constraint/pkg/apis/templates/v1alpha1/register.go
+++ b/constraint/pkg/apis/templates/v1alpha1/register.go
@@ -30,14 +30,15 @@ import (
 )
 
 var (
-	// SchemeGroupVersion is group version used to register these objects
+	// SchemeGroupVersion is group version used to register these objects.
 	SchemeGroupVersion = schema.GroupVersion{Group: "templates.gatekeeper.sh", Version: "v1alpha1"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: SchemeGroupVersion}
 
 	localSchemeBuilder = runtime.NewSchemeBuilder(SchemeBuilder.AddToScheme, addDefaultingFuncs)
 
+	// AddToScheme adds templates/v1alpha1 types to a Scheme.
 	AddToScheme = localSchemeBuilder.AddToScheme
 )
 

--- a/constraint/pkg/apis/templates/v1alpha1/v1alpha1_suite_test.go
+++ b/constraint/pkg/apis/templates/v1alpha1/v1alpha1_suite_test.go
@@ -27,8 +27,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
 
-var cfg *rest.Config
-var c client.Client
+var (
+	cfg *rest.Config
+	c   client.Client
+)
 
 func TestMain(m *testing.M) {
 	t := &envtest.Environment{

--- a/constraint/pkg/apis/templates/v1beta1/constrainttemplate_types.go
+++ b/constraint/pkg/apis/templates/v1beta1/constrainttemplate_types.go
@@ -23,7 +23,7 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// ConstraintTemplateSpec defines the desired state of ConstraintTemplate
+// ConstraintTemplateSpec defines the desired state of ConstraintTemplate.
 type ConstraintTemplateSpec struct {
 	CRD     CRD      `json:"crd,omitempty"`
 	Targets []Target `json:"targets,omitempty"`
@@ -76,7 +76,7 @@ type ByPodStatus struct {
 	Errors             []CreateCRDError `json:"errors,omitempty"`
 }
 
-// ConstraintTemplateStatus defines the observed state of ConstraintTemplate
+// ConstraintTemplateStatus defines the observed state of ConstraintTemplate.
 type ConstraintTemplateStatus struct {
 	Created bool          `json:"created,omitempty"`
 	ByPod   []ByPodStatus `json:"byPod,omitempty"`
@@ -103,7 +103,7 @@ type ConstraintTemplate struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// ConstraintTemplateList contains a list of ConstraintTemplate
+// ConstraintTemplateList contains a list of ConstraintTemplate.
 type ConstraintTemplateList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/constraint/pkg/apis/templates/v1beta1/constrainttemplate_types_test.go
+++ b/constraint/pkg/apis/templates/v1beta1/constrainttemplate_types_test.go
@@ -130,7 +130,7 @@ func TestTypeConversion(t *testing.T) {
 
 // TestValidationVersionConversionAndTransformation confirms that our custom conversion
 // function works, and also that it adds in the x-kubernetes-preserve-unknown-fields information
-// that we require for v1 CRD support
+// that we require for v1 CRD support.
 func TestValidationVersionConversionAndTransformation(t *testing.T) {
 	// The scheme is responsible for defaulting
 	scheme := runtime.NewScheme()

--- a/constraint/pkg/apis/templates/v1beta1/conversion.go
+++ b/constraint/pkg/apis/templates/v1beta1/conversion.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/conversion"
 )
 
-func Convert_v1beta1_Validation_To_templates_Validation(in *Validation, out *coreTemplates.Validation, s conversion.Scope) error { //nolint:golint
+func Convert_v1beta1_Validation_To_templates_Validation(in *Validation, out *coreTemplates.Validation, s conversion.Scope) error { // nolint:revive // Required exact function name.
 	inSchema := in.OpenAPIV3Schema
 
 	// legacySchema should allow for users to provide arbitrary parameters, regardless of whether the user specified them

--- a/constraint/pkg/apis/templates/v1beta1/defaults.go
+++ b/constraint/pkg/apis/templates/v1beta1/defaults.go
@@ -12,7 +12,7 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 	return RegisterDefaults(scheme)
 }
 
-func SetDefaults_ConstraintTemplate(obj *ConstraintTemplate) { //nolint:golint
+func SetDefaults_ConstraintTemplate(obj *ConstraintTemplate) { // nolint:revive // Required exact function name.
 	// turn the CT into an unstructured
 	un, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
 	if err != nil {

--- a/constraint/pkg/apis/templates/v1beta1/helpers.go
+++ b/constraint/pkg/apis/templates/v1beta1/helpers.go
@@ -6,7 +6,7 @@ import (
 )
 
 // ToVersionless runs defaulting functions and then converts the ConstraintTemplate to the
-// versionless api representation
+// versionless api representation.
 func (versioned *ConstraintTemplate) ToVersionless() (*templates.ConstraintTemplate, error) {
 	if err := AddToScheme(apisTemplates.Scheme); err != nil {
 		return nil, err

--- a/constraint/pkg/apis/templates/v1beta1/register.go
+++ b/constraint/pkg/apis/templates/v1beta1/register.go
@@ -30,14 +30,15 @@ import (
 )
 
 var (
-	// SchemeGroupVersion is group version used to register these objects
+	// SchemeGroupVersion is group version used to register these objects.
 	SchemeGroupVersion = schema.GroupVersion{Group: "templates.gatekeeper.sh", Version: "v1beta1"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: SchemeGroupVersion}
 
 	localSchemeBuilder = runtime.NewSchemeBuilder(SchemeBuilder.AddToScheme, addDefaultingFuncs)
 
+	// AddToScheme adds templates/v1beta1 types to a Scheme.
 	AddToScheme = localSchemeBuilder.AddToScheme
 )
 

--- a/constraint/pkg/apis/templates/v1beta1/v1beta1_suite_test.go
+++ b/constraint/pkg/apis/templates/v1beta1/v1beta1_suite_test.go
@@ -27,8 +27,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
 
-var cfg *rest.Config
-var c client.Client
+var (
+	cfg *rest.Config
+	c   client.Client
+)
 
 func TestMain(m *testing.M) {
 	t := &envtest.Environment{

--- a/constraint/pkg/client/backend.go
+++ b/constraint/pkg/client/backend.go
@@ -42,7 +42,7 @@ func NewBackend(opts ...BackendOpt) (*Backend, error) {
 	return b, nil
 }
 
-// NewClient creates a new client for the supplied backend
+// NewClient creates a new client for the supplied backend.
 func (b *Backend) NewClient(opts ...Opt) (*Client, error) {
 	if b.hasClient {
 		return nil, errors.New("Currently only one client per backend is supported")

--- a/constraint/pkg/client/backend.go
+++ b/constraint/pkg/client/backend.go
@@ -2,10 +2,10 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/open-policy-agent/frameworks/constraint/pkg/client/drivers"
-	"errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )

--- a/constraint/pkg/client/backend.go
+++ b/constraint/pkg/client/backend.go
@@ -37,7 +37,7 @@ func NewBackend(opts ...BackendOpt) (*Backend, error) {
 	}
 
 	if b.driver == nil {
-		return nil, errors.New("No driver supplied to the backend")
+		return nil, errors.New("no driver supplied to the backend")
 	}
 
 	return b, nil
@@ -46,7 +46,7 @@ func NewBackend(opts ...BackendOpt) (*Backend, error) {
 // NewClient creates a new client for the supplied backend.
 func (b *Backend) NewClient(opts ...Opt) (*Client, error) {
 	if b.hasClient {
-		return nil, errors.New("Currently only one client per backend is supported")
+		return nil, errors.New("currently only one client per backend is supported")
 	}
 	var fields []string
 	for k := range validDataFields {
@@ -66,14 +66,14 @@ func (b *Backend) NewClient(opts ...Opt) (*Client, error) {
 	}
 	for _, field := range c.allowedDataFields {
 		if !validDataFields[field] {
-			return nil, fmt.Errorf("Invalid data field %s", field)
+			return nil, fmt.Errorf("invalid data field %s", field)
 		}
 	}
 	if len(errs) > 0 {
 		return nil, errs
 	}
 	if len(c.targets) == 0 {
-		return nil, errors.New("No targets registered. Please register a target via client.Targets()")
+		return nil, errors.New("no targets registered: please register a target via client.Targets()")
 	}
 	if err := b.driver.Init(context.Background()); err != nil {
 		return nil, err

--- a/constraint/pkg/client/backend.go
+++ b/constraint/pkg/client/backend.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/open-policy-agent/frameworks/constraint/pkg/client/drivers"
-	"github.com/pkg/errors"
+	"errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )

--- a/constraint/pkg/client/backend.go
+++ b/constraint/pkg/client/backend.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/open-policy-agent/frameworks/constraint/pkg/client/drivers"
 	"github.com/pkg/errors"
@@ -65,7 +66,7 @@ func (b *Backend) NewClient(opts ...Opt) (*Client, error) {
 	}
 	for _, field := range c.allowedDataFields {
 		if !validDataFields[field] {
-			return nil, errors.Errorf("Invalid data field %s", field)
+			return nil, fmt.Errorf("Invalid data field %s", field)
 		}
 	}
 	if len(errs) > 0 {

--- a/constraint/pkg/client/client_test.go
+++ b/constraint/pkg/client/client_test.go
@@ -64,7 +64,7 @@ func (h *badHandler) MatchSchema() apiextensions.JSONSchemaProps {
 
 func (h *badHandler) ProcessData(obj interface{}) (bool, string, interface{}, error) {
 	if h.Errors {
-		return false, "", nil, errors.New("TEST ERROR")
+		return false, "", nil, errors.New("some error")
 	}
 	if !h.HandlesData {
 		return false, "", nil, nil

--- a/constraint/pkg/client/crd_helpers.go
+++ b/constraint/pkg/client/crd_helpers.go
@@ -162,9 +162,9 @@ func (h *crdHelper) createCRD(
 
 // validateCRD calls the CRD package's validation on an internal representation of the CRD.
 func (h *crdHelper) validateCRD(crd *apiextensions.CustomResourceDefinition) error {
-	errors := apiextensionsvalidation.ValidateCustomResourceDefinition(crd, apiextensionsv1.SchemeGroupVersion)
-	if len(errors) > 0 {
-		return errors.ToAggregate()
+	errs := apiextensionsvalidation.ValidateCustomResourceDefinition(crd, apiextensionsv1.SchemeGroupVersion)
+	if len(errs) > 0 {
+		return errs.ToAggregate()
 	}
 	return nil
 }

--- a/constraint/pkg/client/crd_helpers.go
+++ b/constraint/pkg/client/crd_helpers.go
@@ -23,20 +23,25 @@ var supportedVersions = map[string]bool{
 	v1beta1.SchemeGroupVersion.Version:  true,
 }
 
-// validateTargets ensures that the targets field has the appropriate values
+// validateTargets ensures that the targets field has the appropriate values.
 func validateTargets(templ *templates.ConstraintTemplate) error {
-	if len(templ.Spec.Targets) > 1 {
-		return errors.New("Multi-target templates are not currently supported")
-	} else if templ.Spec.Targets == nil {
-		return errors.New(`Field "targets" not specified in ConstraintTemplate spec`)
-	} else if len(templ.Spec.Targets) == 0 {
-		return errors.New("No targets specified. ConstraintTemplate must specify one target")
+	targets := templ.Spec.Targets
+	if targets == nil {
+		return errors.New(`field "targets" not specified in ConstraintTemplate spec`)
 	}
-	return nil
+
+	switch len(targets) {
+	case 0:
+		return errors.New("no targets specified: ConstraintTemplate must specify one target")
+	case 1:
+		return nil
+	default:
+		return errors.New("multi-target templates are not currently supported")
+	}
 }
 
 // createSchema combines the schema of the match target and the ConstraintTemplate parameters
-// to form the schema of the actual constraint resource
+// to form the schema of the actual constraint resource.
 func (h *crdHelper) createSchema(templ *templates.ConstraintTemplate, target MatchSchemaProvider) (*apiextensions.JSONSchemaProps, error) {
 	props := map[string]apiextensions.JSONSchemaProps{
 		"match":             target.MatchSchema(),
@@ -75,7 +80,7 @@ func (h *crdHelper) createSchema(templ *templates.ConstraintTemplate, target Mat
 }
 
 // crdHelper builds the scheme for handling CRDs. It is necessary to build crdHelper at runtime as
-// modules are added to the CRD scheme builder during the init stage
+// modules are added to the CRD scheme builder during the init stage.
 type crdHelper struct {
 	scheme *runtime.Scheme
 }
@@ -88,7 +93,7 @@ func newCRDHelper() (*crdHelper, error) {
 	return &crdHelper{scheme: scheme}, nil
 }
 
-// createCRD takes a template and a schema and converts it to a CRD
+// createCRD takes a template and a schema and converts it to a CRD.
 func (h *crdHelper) createCRD(
 	templ *templates.ConstraintTemplate,
 	schema *apiextensions.JSONSchemaProps) (*apiextensions.CustomResourceDefinition, error) {
@@ -155,7 +160,7 @@ func (h *crdHelper) createCRD(
 	return crd2, nil
 }
 
-// validateCRD calls the CRD package's validation on an internal representation of the CRD
+// validateCRD calls the CRD package's validation on an internal representation of the CRD.
 func (h *crdHelper) validateCRD(crd *apiextensions.CustomResourceDefinition) error {
 	errors := apiextensionsvalidation.ValidateCustomResourceDefinition(crd, apiextensionsv1.SchemeGroupVersion)
 	if len(errors) > 0 {
@@ -164,7 +169,7 @@ func (h *crdHelper) validateCRD(crd *apiextensions.CustomResourceDefinition) err
 	return nil
 }
 
-// validateCR validates the provided custom resource against its CustomResourceDefinition
+// validateCR validates the provided custom resource against its CustomResourceDefinition.
 func (h *crdHelper) validateCR(cr *unstructured.Unstructured, crd *apiextensions.CustomResourceDefinition) error {
 	validator, _, err := validation.NewSchemaValidator(crd.Spec.Validation)
 	if err != nil {

--- a/constraint/pkg/client/crd_helpers.go
+++ b/constraint/pkg/client/crd_helpers.go
@@ -179,16 +179,16 @@ func (h *crdHelper) validateCR(cr *unstructured.Unstructured, crd *apiextensions
 		return err.ToAggregate()
 	}
 	if errs := apivalidation.IsDNS1123Subdomain(cr.GetName()); len(errs) != 0 {
-		return fmt.Errorf("Invalid Name: %s", strings.Join(errs, "\n"))
+		return fmt.Errorf("invalid Name: %s", strings.Join(errs, "\n"))
 	}
 	if cr.GetKind() != crd.Spec.Names.Kind {
-		return fmt.Errorf("Wrong kind for constraint %s. Have %s, want %s", cr.GetName(), cr.GetKind(), crd.Spec.Names.Kind)
+		return fmt.Errorf("wrong kind for constraint %s. Have %s, want %s", cr.GetName(), cr.GetKind(), crd.Spec.Names.Kind)
 	}
 	if cr.GroupVersionKind().Group != constraintGroup {
-		return fmt.Errorf("Wrong group for constraint %s. Have %s, want %s", cr.GetName(), cr.GroupVersionKind().Group, constraintGroup)
+		return fmt.Errorf("wrong group for constraint %s. Have %s, want %s", cr.GetName(), cr.GroupVersionKind().Group, constraintGroup)
 	}
 	if !supportedVersions[cr.GroupVersionKind().Version] {
-		return fmt.Errorf("Wrong version for constraint %s. Have %s, supported: %v", cr.GetName(), cr.GroupVersionKind().Version, supportedVersions)
+		return fmt.Errorf("wrong version for constraint %s. Have %s, supported: %v", cr.GetName(), cr.GroupVersionKind().Version, supportedVersions)
 	}
 	return nil
 }

--- a/constraint/pkg/client/crd_helpers_test.go
+++ b/constraint/pkg/client/crd_helpers_test.go
@@ -93,7 +93,7 @@ func createTestTargetHandler(args ...targetHandlerArg) MatchSchemaProvider {
 	return h
 }
 
-func (h testTargetHandler) MatchSchema() apiextensions.JSONSchemaProps {
+func (h *testTargetHandler) MatchSchema() apiextensions.JSONSchemaProps {
 	return h.matchSchema
 }
 
@@ -110,7 +110,7 @@ func prop(pm ...map[string]apiextensions.JSONSchemaProps) apiextensions.JSONSche
 	return apiextensions.JSONSchemaProps{Type: "object", Properties: pm[0]}
 }
 
-// tProp creates a typed property
+// tProp creates a typed property.
 func tProp(t string) apiextensions.JSONSchemaProps {
 	return apiextensions.JSONSchemaProps{Type: t}
 }
@@ -249,7 +249,9 @@ func TestCreateSchema(t *testing.T) {
 			Handler:  createTestTargetHandler(matchSchema(propMap{"labels": prop()})),
 			ExpectedSchema: expectedSchema(propMap{
 				"match": prop(propMap{
-					"labels": prop()})}),
+					"labels": prop(),
+				}),
+			}),
 		},
 		{
 			Name:     "Just Parameters",

--- a/constraint/pkg/client/drivers/local/local.go
+++ b/constraint/pkg/client/drivers/local/local.go
@@ -109,20 +109,20 @@ func copyModules(modules map[string]*ast.Module, filter string) map[string]*ast.
 
 func (d *driver) checkModuleName(name string) error {
 	if name == "" {
-		return errors.Errorf("Module name cannot be empty")
+		return fmt.Errorf("Module name cannot be empty")
 	}
 	if strings.HasPrefix(name, moduleSetPrefix) {
-		return errors.Errorf("Single modules not allowed to use name prefix %s", moduleSetPrefix)
+		return fmt.Errorf("Single modules not allowed to use name prefix %s", moduleSetPrefix)
 	}
 	return nil
 }
 
 func (d *driver) checkModuleSetName(name string) error {
 	if name == "" {
-		return errors.Errorf("Modules name prefix cannot be empty")
+		return fmt.Errorf("Modules name prefix cannot be empty")
 	}
 	if strings.Contains(name, moduleSetSep) {
-		return errors.Errorf("Modules name prefix not allowed to contain the sequence n%s", moduleSetSep)
+		return fmt.Errorf("Modules name prefix not allowed to contain the sequence n%s", moduleSetSep)
 	}
 	return nil
 }
@@ -334,16 +334,17 @@ func (d *driver) eval(ctx context.Context, path string, input interface{}, cfg *
 	}
 	if d.traceEnabled || cfg.TracingEnabled {
 		buf := topdown.NewBufferTracer()
-		args = append(args, rego.Tracer(buf))
-		rego := rego.New(args...)
-		res, err := rego.Eval(ctx)
+		args = append(args, rego.QueryTracer(buf))
+		r := rego.New(args...)
+		res, err := r.Eval(ctx)
 		b := &bytes.Buffer{}
 		topdown.PrettyTrace(b, *buf)
 		t := b.String()
 		return res, &t, err
 	}
-	rego := rego.New(args...)
-	res, err := rego.Eval(ctx)
+
+	r := rego.New(args...)
+	res, err := r.Eval(ctx)
 	return res, nil, err
 }
 

--- a/constraint/pkg/client/drivers/local/local.go
+++ b/constraint/pkg/client/drivers/local/local.go
@@ -109,20 +109,20 @@ func copyModules(modules map[string]*ast.Module, filter string) map[string]*ast.
 
 func (d *driver) checkModuleName(name string) error {
 	if name == "" {
-		return fmt.Errorf("Module name cannot be empty")
+		return fmt.Errorf("module name cannot be empty")
 	}
 	if strings.HasPrefix(name, moduleSetPrefix) {
-		return fmt.Errorf("Single modules not allowed to use name prefix %s", moduleSetPrefix)
+		return fmt.Errorf("single modules not allowed to use name prefix %q", moduleSetPrefix)
 	}
 	return nil
 }
 
 func (d *driver) checkModuleSetName(name string) error {
 	if name == "" {
-		return fmt.Errorf("Modules name prefix cannot be empty")
+		return fmt.Errorf("modules name prefix cannot be empty")
 	}
 	if strings.Contains(name, moduleSetSep) {
-		return fmt.Errorf("Modules name prefix not allowed to contain the sequence n%s", moduleSetSep)
+		return fmt.Errorf("modules name prefix not allowed to contain the sequence n%s", moduleSetSep)
 	}
 	return nil
 }
@@ -259,7 +259,7 @@ func (d *driver) listModuleSet(namePrefix string) []string {
 func parsePath(path string) ([]string, error) {
 	p, ok := storage.ParsePathEscaped(path)
 	if !ok {
-		return nil, fmt.Errorf("Bad data path: %s", path)
+		return nil, fmt.Errorf("bad data path: %q", path)
 	}
 	return p, nil
 }
@@ -397,11 +397,11 @@ func (d *driver) Dump(ctx context.Context) (string, error) {
 	var dt interface{}
 	// There should be only 1 or 0 expression values
 	if len(data) > 1 {
-		return "", errors.New("Too many dump results")
+		return "", errors.New("too many dump results")
 	}
 	for _, da := range data {
 		if len(data) > 1 {
-			return "", errors.New("Too many expressions results")
+			return "", errors.New("too many expressions results")
 		}
 		for _, e := range da.Expressions {
 			dt = e.Value

--- a/constraint/pkg/client/drivers/local/local.go
+++ b/constraint/pkg/client/drivers/local/local.go
@@ -18,8 +18,10 @@ import (
 	"github.com/pkg/errors"
 )
 
-const moduleSetPrefix = "__modset_"
-const moduleSetSep = "_idx_"
+const (
+	moduleSetPrefix = "__modset_"
+	moduleSetSep    = "_idx_"
+)
 
 type module struct {
 	text   string
@@ -143,7 +145,7 @@ func (d *driver) PutModule(ctx context.Context, name string, src string) error {
 	return err
 }
 
-// PutModules implements drivers.Driver
+// PutModules implements drivers.Driver.
 func (d *driver) PutModules(ctx context.Context, namePrefix string, srcs []string) error {
 	if err := d.checkModuleSetName(namePrefix); err != nil {
 		return err
@@ -171,7 +173,7 @@ func (d *driver) PutModules(ctx context.Context, namePrefix string, srcs []strin
 }
 
 // DeleteModule deletes a rule from OPA and returns true if a rule was found and deleted, false
-// if a rule was not found, and any errors
+// if a rule was not found, and any errors.
 func (d *driver) DeleteModule(ctx context.Context, name string) (bool, error) {
 	if err := d.checkModuleName(name); err != nil {
 		return false, err
@@ -230,7 +232,7 @@ func (d *driver) alterModules(ctx context.Context, insert insertParam, remove []
 	return len(remove), nil
 }
 
-// DeleteModules implements drivers.Driver
+// DeleteModules implements drivers.Driver.
 func (d *driver) DeleteModules(ctx context.Context, namePrefix string) (int, error) {
 	if err := d.checkModuleSetName(namePrefix); err != nil {
 		return 0, err
@@ -291,14 +293,12 @@ func (d *driver) PutData(ctx context.Context, path string, data interface{}) err
 		d.storage.Abort(ctx, txn)
 		return err
 	}
-	if err := d.storage.Commit(ctx, txn); err != nil {
-		return err
-	}
-	return nil
+
+	return d.storage.Commit(ctx, txn)
 }
 
 // DeleteData deletes data from OPA and returns true if data was found and deleted, false
-// if data was not found, and any errors
+// if data was not found, and any errors.
 func (d *driver) DeleteData(ctx context.Context, path string) (bool, error) {
 	d.modulesMux.RLock()
 	defer d.modulesMux.RUnlock()

--- a/constraint/pkg/client/drivers/local/local.go
+++ b/constraint/pkg/client/drivers/local/local.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -15,7 +16,6 @@ import (
 	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/storage/inmem"
 	"github.com/open-policy-agent/opa/topdown"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/constraint/pkg/client/drivers/local/local_test.go
+++ b/constraint/pkg/client/drivers/local/local_test.go
@@ -151,7 +151,7 @@ func (tt *compositeTestCase) run(t *testing.T) {
 }
 
 func resultsEqual(res rego.ResultSet, exp []string, t *testing.T) bool {
-	ev := []string{}
+	var ev []string
 	for _, r := range res {
 		i, ok := r.Bindings["a"].(string)
 		if !ok {

--- a/constraint/pkg/client/drivers/remote/httpclient.go
+++ b/constraint/pkg/client/drivers/remote/httpclient.go
@@ -68,7 +68,8 @@ type Data interface {
 // New returns a new client object.
 func newHTTPClient(url string, opaCAs *x509.CertPool, auth string) client {
 	return &httpClient{
-		strings.TrimRight(url, "/"), "", opaCAs, auth}
+		strings.TrimRight(url, "/"), "", opaCAs, auth,
+	}
 }
 
 type httpClient struct {
@@ -262,7 +263,7 @@ func (c *httpClient) do(verb, path string, body io.Reader) (*http.Response, erro
 	client := &http.Client{}
 	if strings.HasPrefix(c.url, "https") && c.opaCAs != nil {
 		client.Transport = &http.Transport{
-			TLSClientConfig: &tls.Config{
+			TLSClientConfig: &tls.Config{ // nolint:gosec // TODO: Determine appropriate minimum TLS version.
 				RootCAs: c.opaCAs,
 			},
 		}

--- a/constraint/pkg/client/drivers/remote/httpclient.go
+++ b/constraint/pkg/client/drivers/remote/httpclient.go
@@ -14,8 +14,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // Error contains the standard error fields returned by OPA.
@@ -88,11 +86,11 @@ func (c *httpClient) Prefix(path string) Data {
 func (c *httpClient) PatchData(path string, op string, value *interface{}) error {
 	buf, err := c.makePatch(path, op, value)
 	if err != nil {
-		return errors.Wrap(err, "PatchData")
+		return fmt.Errorf("got PatchData: %w", err)
 	}
 	resp, err := c.do("PATCH", slashPath("v1", "data"), buf)
 	if err != nil {
-		return errors.Wrap(err, "PatchData")
+		return fmt.Errorf("got PatchData: %w", err)
 	}
 	return c.handleErrors(resp)
 }
@@ -100,12 +98,12 @@ func (c *httpClient) PatchData(path string, op string, value *interface{}) error
 func (c *httpClient) PutData(path string, value interface{}) error {
 	var buf bytes.Buffer
 	if err := json.NewEncoder(&buf).Encode(value); err != nil {
-		return errors.Wrap(err, "PutData")
+		return fmt.Errorf("got PutData: %w", err)
 	}
 	absPath := slashPath("v1", "data", c.prefix, path)
 	resp, err := c.do("PUT", absPath, &buf)
 	if err != nil {
-		return errors.Wrap(err, "PutData")
+		return fmt.Errorf("got PutData: %w", err)
 	}
 	return c.handleErrors(resp)
 }
@@ -144,7 +142,7 @@ func (c *httpClient) DeleteData(path string) error {
 	absPath := slashPath("v1", "data", c.prefix, path)
 	resp, err := c.do("DELETE", absPath, nil)
 	if err != nil {
-		return errors.Wrap(err, "DeleteData")
+		return fmt.Errorf("got DeleteData: %w", err)
 	}
 	return c.handleErrors(resp)
 }
@@ -162,7 +160,7 @@ func (c *httpClient) Query(path string, input interface{}) (*QueryResult, error)
 	}
 	body.Input = input
 	if err := json.NewEncoder(&buf).Encode(body); err != nil {
-		return nil, errors.Wrap(err, "Query:body")
+		return nil, fmt.Errorf("got encoding Query:body: %w", err)
 	}
 	absPath := slashPath("v1", "data", c.prefix, path)
 	method := "GET"
@@ -171,14 +169,14 @@ func (c *httpClient) Query(path string, input interface{}) (*QueryResult, error)
 	}
 	resp, err := c.do(method, absPath, &buf)
 	if err != nil {
-		return nil, errors.Wrap(err, "Query:do")
+		return nil, fmt.Errorf("got running Query:do: %w", err)
 	}
 	result := &QueryResult{}
 	if resp.StatusCode != 200 {
-		return nil, errors.Wrap(c.handleErrors(resp), "Query:handleErrors")
+		return nil, fmt.Errorf("got error running Query:handleErrors: %w", c.handleErrors(resp))
 	}
 	if err := json.NewDecoder(resp.Body).Decode(result); err != nil {
-		return nil, errors.Wrapf(err, "Query")
+		return nil, fmt.Errorf("got decoding Query: %w", err)
 	}
 	return result, nil
 }
@@ -188,7 +186,7 @@ func (c *httpClient) InsertPolicy(id string, bs []byte) error {
 	path := slashPath("v1", "policies", id)
 	resp, err := c.do("PUT", path, buf)
 	if err != nil {
-		return errors.Wrap(err, "InsertPolicy")
+		return fmt.Errorf("got InsertPolicy: %w", err)
 	}
 	return c.handleErrors(resp)
 }
@@ -197,7 +195,7 @@ func (c *httpClient) DeletePolicy(id string) error {
 	path := slashPath("v1", "policies", id)
 	resp, err := c.do("DELETE", path, nil)
 	if err != nil {
-		return errors.Wrap(err, "DeletePolicy")
+		return fmt.Errorf("got DeletePolicy: %w", err)
 	}
 	return c.handleErrors(resp)
 }
@@ -206,14 +204,14 @@ func (c *httpClient) ListPolicies() (*QueryResult, error) {
 	absPath := slashPath("v1", "policies", c.prefix)
 	resp, err := c.do("GET", absPath, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "ListPolicies:do")
+		return nil, fmt.Errorf("got ListPolicies:do: %w", err)
 	}
 	result := &QueryResult{}
 	if resp.StatusCode != 200 {
-		return nil, errors.Wrap(c.handleErrors(resp), "ListPolicies:handleErrors")
+		return nil, fmt.Errorf("got running ListPolicies:handleErrors: %w", c.handleErrors(resp))
 	}
 	if err := json.NewDecoder(resp.Body).Decode(result); err != nil {
-		return nil, errors.Wrapf(err, "ListPolicies")
+		return nil, fmt.Errorf("got decoding ListPolicies: %w", err, )
 	}
 	return result, nil
 }
@@ -244,7 +242,7 @@ func (c *httpClient) handleErrors(resp *http.Response) error {
 	}
 	msg, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return errors.Wrapf(err, "handleErrors")
+		return fmt.Errorf("got handleErrors: %w", err)
 	}
 	return &Error{Message: string(msg), Status: resp.StatusCode}
 }

--- a/constraint/pkg/client/drivers/remote/httpclient.go
+++ b/constraint/pkg/client/drivers/remote/httpclient.go
@@ -281,7 +281,7 @@ func makePath(join string, paths ...string) string {
 }
 
 func joinPaths(join string, paths ...string) string {
-	parts := []string{}
+	var parts []string
 	for _, path := range paths {
 		path = strings.Trim(path, join)
 		if path != "" {

--- a/constraint/pkg/client/drivers/remote/httpclient.go
+++ b/constraint/pkg/client/drivers/remote/httpclient.go
@@ -211,7 +211,7 @@ func (c *httpClient) ListPolicies() (*QueryResult, error) {
 		return nil, fmt.Errorf("got running ListPolicies:handleErrors: %w", c.handleErrors(resp))
 	}
 	if err := json.NewDecoder(resp.Body).Decode(result); err != nil {
-		return nil, fmt.Errorf("got decoding ListPolicies: %w", err, )
+		return nil, fmt.Errorf("got decoding ListPolicies: %w", err)
 	}
 	return result, nil
 }

--- a/constraint/pkg/client/drivers/remote/httpclient_test.go
+++ b/constraint/pkg/client/drivers/remote/httpclient_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestHTTPClientMakePatch(t *testing.T) {
-
 	tests := []struct {
 		prefix string
 		path   string
@@ -64,7 +63,6 @@ func TestHTTPClientMakePatch(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-
 		client := &httpClient{"URL", tc.prefix, nil, ""}
 		var value *interface{}
 
@@ -87,11 +85,9 @@ func TestHTTPClientMakePatch(t *testing.T) {
 			t.Errorf("Expected %v but got: %v", expected, patch)
 		}
 	}
-
 }
 
 func mustMakePatch(client *httpClient, path, op string, value *interface{}) interface{} {
-
 	buf, err := client.makePatch(path, op, value)
 	if err != nil {
 		panic(err)

--- a/constraint/pkg/client/drivers/remote/remote.go
+++ b/constraint/pkg/client/drivers/remote/remote.go
@@ -156,7 +156,7 @@ func makeURLPath(path string) (string, error) {
 			quoted = !quoted
 			continue
 		}
-		fmt.Fprint(builder, ch)
+		_, _ = fmt.Fprint(builder, ch)
 	}
 	pieces = append(pieces, builder.String())
 

--- a/constraint/pkg/client/drivers/remote/remote.go
+++ b/constraint/pkg/client/drivers/remote/remote.go
@@ -52,7 +52,7 @@ func New(args ...Arg) (drivers.Driver, error) {
 		arg(i)
 	}
 	if i.url == "" {
-		return nil, errors.New("OPA URL not set")
+		return nil, errors.New("missing URL for OPA")
 	}
 	return &driver{opa: newHTTPClient(i.url, i.opaCAs, i.auth), traceEnabled: i.traceEnabled}, nil
 }
@@ -140,7 +140,7 @@ func makeURLPath(path string) (string, error) {
 					builder.Reset()
 					continue
 				} else {
-					return "", fmt.Errorf("Mismatched bracketing: %s", path)
+					return "", fmt.Errorf("mismatched bracketing: %q", path)
 				}
 			}
 			if ch == "]" {
@@ -148,7 +148,7 @@ func makeURLPath(path string) (string, error) {
 					openBracket = false
 					continue
 				} else {
-					return "", fmt.Errorf("Mismatched bracketing: %s", path)
+					return "", fmt.Errorf("mismatched bracketing: %q", path)
 				}
 			}
 		}

--- a/constraint/pkg/client/drivers/remote/remote.go
+++ b/constraint/pkg/client/drivers/remote/remote.go
@@ -76,13 +76,13 @@ func (d *driver) PutModule(ctx context.Context, name string, src string) error {
 	return d.opa.InsertPolicy(name, []byte(src))
 }
 
-// PutModules implements drivers.Driver
+// PutModules implements drivers.Driver.
 func (d *driver) PutModules(ctx context.Context, namePrefix string, srcs []string) error {
 	panic("not implemented")
 }
 
 // DeleteModule deletes a rule from OPA and returns true if a rule was found and deleted, false
-// if a rule was not found, and any errors
+// if a rule was not found, and any errors.
 func (d *driver) DeleteModule(ctx context.Context, name string) (bool, error) {
 	err := d.opa.DeletePolicy(name)
 	if err != nil {
@@ -95,7 +95,7 @@ func (d *driver) DeleteModule(ctx context.Context, name string) (bool, error) {
 	return err == nil, err
 }
 
-// DeleteModules implements drivers.Driver
+// DeleteModules implements drivers.Driver.
 func (d *driver) DeleteModules(ctx context.Context, namePrefix string) (int, error) {
 	panic("not implemented")
 }
@@ -105,7 +105,7 @@ func (d *driver) PutData(ctx context.Context, path string, data interface{}) err
 }
 
 // DeleteData deletes data from OPA and returns true if data was found and deleted, false
-// if data was not found, and any errors
+// if data was not found, and any errors.
 func (d *driver) DeleteData(ctx context.Context, path string) (bool, error) {
 	err := d.opa.DeleteData(path)
 	if err != nil {
@@ -119,7 +119,7 @@ func (d *driver) DeleteData(ctx context.Context, path string) (bool, error) {
 }
 
 // makeURLPath takes a path of the form data.foo["bar.baz"].yes and converts it to an URI path
-// such as /data/foo/bar.baz/yes
+// such as /data/foo/bar.baz/yes.
 func makeURLPath(path string) (string, error) {
 	var pieces []string
 	quoted := false

--- a/constraint/pkg/client/drivers/remote/remote_test.go
+++ b/constraint/pkg/client/drivers/remote/remote_test.go
@@ -12,15 +12,15 @@ type testClient struct {
 }
 
 func (c *testClient) InsertPolicy(id string, bs []byte) error {
-	return errors.New("NOT IMPLEMENTED")
+	return errors.New("not implemented")
 }
 
 func (c *testClient) DeletePolicy(id string) error {
-	return errors.New("NOT IMPLEMENTED")
+	return errors.New("not implemented")
 }
 
 func (c *testClient) ListPolicies() (*QueryResult, error) {
-	return nil, errors.New("NOT IMPLEMENTED")
+	return nil, errors.New("not implemented")
 }
 
 func (c *testClient) Prefix(path string) Data {
@@ -28,19 +28,19 @@ func (c *testClient) Prefix(path string) Data {
 }
 
 func (c *testClient) PatchData(path string, op string, value *interface{}) error {
-	return errors.New("NOT IMPLEMENTED")
+	return errors.New("not implemented")
 }
 
 func (c *testClient) PutData(path string, value interface{}) error {
-	return errors.New("NOT IMPLEMENTED")
+	return errors.New("not implemented")
 }
 
 func (c *testClient) PostData(path string, value interface{}) (json.RawMessage, error) {
-	return nil, errors.New("NOT IMPLEMENTED")
+	return nil, errors.New("not implemented")
 }
 
 func (c *testClient) DeleteData(path string) error {
-	return errors.New("NOT IMPLEMENTED")
+	return errors.New("not implemented")
 }
 
 func (c *testClient) Query(path string, value interface{}) (*QueryResult, error) {

--- a/constraint/pkg/client/e2e_tests.go
+++ b/constraint/pkg/client/e2e_tests.go
@@ -74,13 +74,13 @@ func newConstraint(kind, name string, params map[string]string, enforcementActio
 }
 
 var (
-	// basic deny template
+	// basic deny template.
 	denyTemplateRego = `package foo
 violation[{"msg": "DENIED", "details": {}}] {
 	"always" == "always"
 }`
 
-	// basic deny template that uses a lib rule
+	// basic deny template that uses a lib rule.
 	denyTemplateWithLibRego = `package foo
 
 import data.lib.bar

--- a/constraint/pkg/client/e2e_tests.go
+++ b/constraint/pkg/client/e2e_tests.go
@@ -122,7 +122,7 @@ func addDenyAllE2ETests(nameSuffix string, rego string, libs ...string) {
 			return errors.Wrap(err, "Review")
 		}
 		if len(rsps.ByTarget) == 0 {
-			return errors.New("No responses returned")
+			return errors.New("no responses returned")
 		}
 		if len(rsps.Results()) != 1 {
 			return e("Bad number of results", rsps)
@@ -161,7 +161,7 @@ func addDenyAllE2ETests(nameSuffix string, rego string, libs ...string) {
 			return errors.Wrap(err, "Audit")
 		}
 		if len(rsps.ByTarget) == 0 {
-			return errors.New("No responses returned")
+			return errors.New("no responses returned")
 		}
 		if len(rsps.Results()) != 2 {
 			return e("Bad number of results", rsps)
@@ -195,7 +195,7 @@ func addDenyAllE2ETests(nameSuffix string, rego string, libs ...string) {
 			return errors.Wrap(err, "Audit")
 		}
 		if len(rsps.ByTarget) == 0 {
-			return errors.New("No responses returned")
+			return errors.New("no responses returned")
 		}
 		if len(rsps.Results()) != 1 {
 			return e("Bad number of results", rsps)
@@ -258,7 +258,7 @@ func addDenyAllE2ETests(nameSuffix string, rego string, libs ...string) {
 			return errors.Wrap(err, "Review")
 		}
 		if len(rsps.ByTarget) == 0 {
-			return errors.New("No responses returned")
+			return errors.New("no responses returned")
 		}
 		if len(rsps.Results()) != 2 {
 			return e("Bad number of results", rsps)
@@ -296,7 +296,7 @@ func addDenyAllE2ETests(nameSuffix string, rego string, libs ...string) {
 			return errors.Wrap(err, "Audit")
 		}
 		if len(rsps.ByTarget) == 0 {
-			return errors.New("No responses returned")
+			return errors.New("no responses returned")
 		}
 		if len(rsps.Results()) != 2 {
 			return e("Bad number of results", rsps)
@@ -318,7 +318,7 @@ func addDenyAllE2ETests(nameSuffix string, rego string, libs ...string) {
 			return errors.Wrapf(err, "AuditX2")
 		}
 		if len(rsps2.ByTarget) == 0 {
-			return errors.New("No responses returned")
+			return errors.New("no responses returned")
 		}
 		if len(rsps2.Results()) != 1 {
 			return e("Bad number of results", rsps2)
@@ -353,7 +353,7 @@ func addDenyAllE2ETests(nameSuffix string, rego string, libs ...string) {
 			return errors.Wrap(err, "Audit")
 		}
 		if len(rsps.ByTarget) == 0 {
-			return errors.New("No responses returned")
+			return errors.New("no responses returned")
 		}
 		if len(rsps.Results()) != 1 {
 			return e("Bad number of results", rsps)
@@ -400,7 +400,7 @@ func addDenyAllE2ETests(nameSuffix string, rego string, libs ...string) {
 			return errors.Wrap(err, "Audit")
 		}
 		if len(rsps.ByTarget) == 0 {
-			return errors.New("No responses returned")
+			return errors.New("no responses returned")
 		}
 		if len(rsps.Results()) != 1 {
 			return e("Bad number of results", rsps)
@@ -442,7 +442,7 @@ func addDenyAllE2ETests(nameSuffix string, rego string, libs ...string) {
 			return errors.Wrap(err, "Review")
 		}
 		if len(rsps.ByTarget) == 0 {
-			return errors.New("No responses returned")
+			return errors.New("no responses returned")
 		}
 		if len(rsps.Results()) != 1 {
 			return e("Bad number of results", rsps)
@@ -469,7 +469,7 @@ func addDenyAllE2ETests(nameSuffix string, rego string, libs ...string) {
 			return errors.Wrap(err, "Review")
 		}
 		if len(rsps.ByTarget) == 0 {
-			return errors.New("No responses returned")
+			return errors.New("no responses returned")
 		}
 		if len(rsps.Results()) != 1 {
 			return e("Bad number of results", rsps)
@@ -504,7 +504,7 @@ func addDenyAllE2ETests(nameSuffix string, rego string, libs ...string) {
 			return errors.Wrap(err, "Audit")
 		}
 		if len(rsps.ByTarget) == 0 {
-			return errors.New("No responses returned")
+			return errors.New("no responses returned")
 		}
 		if len(rsps.Results()) != 2 {
 			return e("Bad number of results", rsps)
@@ -539,7 +539,7 @@ func addDenyAllE2ETests(nameSuffix string, rego string, libs ...string) {
 			return errors.Wrap(err, "Audit")
 		}
 		if len(rsps.ByTarget) == 0 {
-			return errors.New("No responses returned")
+			return errors.New("no responses returned")
 		}
 		if len(rsps.Results()) != 2 {
 			return e("Bad number of results", rsps)
@@ -577,7 +577,7 @@ violation[{"msg": "DRYRUN", "details": {}}] {
 			return errors.Wrap(err, "Review")
 		}
 		if len(rsps.ByTarget) == 0 {
-			return errors.New("No responses returned")
+			return errors.New("no responses returned")
 		}
 		if len(rsps.Results()) != 1 {
 			return e("Bad number of results", rsps)
@@ -608,7 +608,7 @@ violation[{"msg": "DENIED", "details": {}}] {
 			return errors.Wrap(err, "Review")
 		}
 		if len(rsps.ByTarget) == 0 {
-			return errors.New("No responses returned")
+			return errors.New("no responses returned")
 		}
 		if len(rsps.Results()) != 1 {
 			return e("Bad number of results", rsps)
@@ -625,7 +625,7 @@ violation[{"msg": "DENIED", "details": {}}] {
 			return errors.Wrap(err, "Review")
 		}
 		if len(rsps.ByTarget) == 0 {
-			return errors.New("No responses returned for second test")
+			return errors.New("no responses returned for second test")
 		}
 		if len(rsps.Results()) != 0 {
 			return e("Expected no results", rsps)

--- a/constraint/pkg/client/errors.go
+++ b/constraint/pkg/client/errors.go
@@ -8,7 +8,7 @@ import (
 // Errors is a list of error.
 type Errors []error
 
-// Errors implements error
+// Errors implements error.
 var _ error = Errors{}
 
 // Error implements error.

--- a/constraint/pkg/client/errors.go
+++ b/constraint/pkg/client/errors.go
@@ -25,7 +25,7 @@ type ErrorMap map[string]error
 func (e ErrorMap) Error() string {
 	b := &strings.Builder{}
 	for k, v := range e {
-		fmt.Fprintf(b, "%s: %s\n", k, v)
+		_, _ = fmt.Fprintf(b, "%s: %s\n", k, v)
 	}
 	return b.String()
 }

--- a/constraint/pkg/client/probe_client.go
+++ b/constraint/pkg/client/probe_client.go
@@ -37,7 +37,7 @@ func (p *Probe) TestFuncs() map[string]func() error {
 	return ret
 }
 
-// This must be a separate function to create a separate closure for each test
+// This must be a separate function to create a separate closure for each test.
 func (p *Probe) runTest(name string) func() error {
 	return func() error {
 		if err := p.client.Reset(context.Background()); err != nil {
@@ -49,7 +49,7 @@ func (p *Probe) runTest(name string) func() error {
 			if err2 != nil {
 				dump = err2.Error()
 			}
-			return fmt.Errorf("error: %s\n\nOPA Dump: %s\n", err, dump) //nolint:golint
+			return fmt.Errorf("error: %s\n\nOPA Dump: %s", err, dump)
 		}
 		return nil
 	}

--- a/constraint/pkg/client/rego_helpers.go
+++ b/constraint/pkg/client/rego_helpers.go
@@ -1,10 +1,10 @@
 package client
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/open-policy-agent/opa/ast"
-	"errors"
 )
 
 // Currently rules should only access data.inventory.

--- a/constraint/pkg/client/rego_helpers.go
+++ b/constraint/pkg/client/rego_helpers.go
@@ -19,7 +19,7 @@ func parseModule(path, rego string) (*ast.Module, error) {
 		return nil, err
 	}
 	if module == nil {
-		return nil, errors.New("Empty module")
+		return nil, errors.New("empty module")
 	}
 	return module, nil
 }
@@ -47,7 +47,7 @@ func requireRulesModule(module *ast.Module, requiredRules map[string]struct{}) e
 	for name := range requiredRules {
 		_, ok := ruleSets[name]
 		if !ok {
-			errs = append(errs, fmt.Errorf("Missing required rule: %s", name))
+			errs = append(errs, fmt.Errorf("missing required rule: %s", name))
 			continue
 		}
 	}

--- a/constraint/pkg/client/rego_helpers.go
+++ b/constraint/pkg/client/rego_helpers.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/open-policy-agent/opa/ast"
-	"github.com/pkg/errors"
+	"errors"
 )
 
 // Currently rules should only access data.inventory.

--- a/constraint/pkg/client/rego_helpers.go
+++ b/constraint/pkg/client/rego_helpers.go
@@ -7,12 +7,10 @@ import (
 	"github.com/pkg/errors"
 )
 
-var (
-	// Currently rules should only access data.inventory
-	validDataFields = map[string]bool{
-		"inventory": true,
-	}
-)
+// Currently rules should only access data.inventory.
+var validDataFields = map[string]bool{
+	"inventory": true,
+}
 
 // parseModule parses the module and also fails empty modules.
 func parseModule(path, rego string) (*ast.Module, error) {
@@ -38,7 +36,7 @@ func rewriteModulePackage(path string, module *ast.Module) error {
 	return nil
 }
 
-// requireRulesModule makes sure the listed rules are specified
+// requireRulesModule makes sure the listed rules are specified.
 func requireRulesModule(module *ast.Module, requiredRules map[string]struct{}) error {
 	ruleSets := make(map[string]struct{}, len(module.Rules))
 	for _, rule := range module.Rules {

--- a/constraint/pkg/client/regolib/templates.go
+++ b/constraint/pkg/client/regolib/templates.go
@@ -2,4 +2,5 @@ package regolib
 
 import "text/template"
 
+// TargetLib is the a parsed text template for Rego tests.
 var TargetLib = template.Must(template.New("TargetLib").Parse(targetLibSrc))

--- a/constraint/pkg/core/constraints/constraints.go
+++ b/constraint/pkg/core/constraints/constraints.go
@@ -9,7 +9,7 @@ import (
 // SemanticEqual returns whether the specs of the constraints are equal. It
 // ignores status and metadata because neither are relevant as to how a
 // constraint is enforced. It is assumed that the author is comparing
-// two constraints with the same GVK/namespace/name
+// two constraints with the same GVK/namespace/name.
 func SemanticEqual(c1 *unstructured.Unstructured, c2 *unstructured.Unstructured) bool {
 	s1, exists, err := unstructured.NestedMap(c1.Object, "spec")
 	if err != nil || !exists {

--- a/constraint/pkg/core/templates/constrainttemplate_types.go
+++ b/constraint/pkg/core/templates/constrainttemplate_types.go
@@ -25,7 +25,7 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// ConstraintTemplateSpec defines the desired state of ConstraintTemplate
+// ConstraintTemplateSpec defines the desired state of ConstraintTemplate.
 type ConstraintTemplateSpec struct {
 	CRD     CRD      `json:"crd,omitempty"`
 	Targets []Target `json:"targets,omitempty"`
@@ -65,7 +65,7 @@ type CreateCRDError struct {
 }
 
 // ByPodStatus defines the observed state of ConstraintTemplate as seen by
-// an individual controller
+// an individual controller.
 type ByPodStatus struct {
 	// a unique identifier for the pod that wrote the status
 	ID                 string           `json:"id,omitempty"`
@@ -73,7 +73,7 @@ type ByPodStatus struct {
 	Errors             []CreateCRDError `json:"errors,omitempty"`
 }
 
-// ConstraintTemplateStatus defines the observed state of ConstraintTemplate
+// ConstraintTemplateStatus defines the observed state of ConstraintTemplate.
 type ConstraintTemplateStatus struct {
 	Created bool          `json:"created,omitempty"`
 	ByPod   []ByPodStatus `json:"byPod,omitempty"`
@@ -98,7 +98,7 @@ type ConstraintTemplate struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// ConstraintTemplateList contains a list of ConstraintTemplate
+// ConstraintTemplateList contains a list of ConstraintTemplate.
 type ConstraintTemplateList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
@@ -107,7 +107,7 @@ type ConstraintTemplateList struct {
 
 // SemanticEqual returns whether there have been changes to a constraint that
 // the framework should know about. It can ignore metadata as it assumes the
-// two comparables share the same identity
+// two comparables share the same identity.
 func (ct *ConstraintTemplate) SemanticEqual(other *ConstraintTemplate) bool {
 	return reflect.DeepEqual(ct.Spec, other.Spec)
 }

--- a/constraint/pkg/regorewriter/ast_helpers.go
+++ b/constraint/pkg/regorewriter/ast_helpers.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/open-policy-agent/opa/ast"
-	"github.com/pkg/errors"
 )
 
 var (
@@ -44,7 +43,7 @@ func packagesAsRefs(strs []string) ([]ast.Ref, error) {
 			return nil, fmt.Errorf("invalid ref input %s", s)
 		}
 		if !dataVarTerm.Equal(ref[0]) {
-			return nil, errors.Wrapf(err, "ref must start with data")
+			return nil, fmt.Errorf("ref must start with data: %w", err)
 		}
 		refs = append(refs, ref)
 	}

--- a/constraint/pkg/regorewriter/ast_helpers.go
+++ b/constraint/pkg/regorewriter/ast_helpers.go
@@ -1,6 +1,8 @@
 package regorewriter
 
 import (
+	"fmt"
+
 	"github.com/golang/glog"
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/pkg/errors"
@@ -39,7 +41,7 @@ func packagesAsRefs(strs []string) ([]ast.Ref, error) {
 			return nil, err
 		}
 		if len(ref) == 0 {
-			return nil, errors.Errorf("invalid ref input %s", s)
+			return nil, fmt.Errorf("invalid ref input %s", s)
 		}
 		if !dataVarTerm.Equal(ref[0]) {
 			return nil, errors.Wrapf(err, "ref must start with data")

--- a/constraint/pkg/regorewriter/doc.go
+++ b/constraint/pkg/regorewriter/doc.go
@@ -1,5 +1,5 @@
 /*
-package regorewriter rewrites import and package refs for a set of rego modules.
+Package regorewriter rewrites import and package refs for a set of rego modules.
 
 Rego modules are divided into two categories: libraries and constraint templates.  The libraries
 will have both package path, imports and data references updated while the constraint templates

--- a/constraint/pkg/regorewriter/errors.go
+++ b/constraint/pkg/regorewriter/errors.go
@@ -24,20 +24,20 @@ func (errs Errors) Error() string {
 func (errs Errors) Format(s fmt.State, verb rune) {
 	switch verb {
 	case 'v':
-		fmt.Fprintf(s, "errors (%d):\n", len(errs))
+		_, _ = fmt.Fprintf(s, "errors (%d):\n", len(errs))
 		for _, err := range errs {
 			if formatter, ok := err.(fmt.Formatter); ok {
 				formatter.Format(s, verb)
-				io.WriteString(s, "\n")
+				_, _ = io.WriteString(s, "\n")
 			} else {
-				fmt.Fprintf(s, "%v\n", err)
+				_, _ = fmt.Fprintf(s, "%v\n", err)
 			}
 		}
 
 	case 's':
-		io.WriteString(s, errs.Error())
+		_, _ = io.WriteString(s, errs.Error())
 
 	case 'q':
-		fmt.Fprintf(s, "%q", errs.Error())
+		_, _ = fmt.Fprintf(s, "%q", errs.Error())
 	}
 }

--- a/constraint/pkg/regorewriter/filepath.go
+++ b/constraint/pkg/regorewriter/filepath.go
@@ -1,10 +1,9 @@
 package regorewriter
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // FilePath represents a path on the filesystem and handles reparenting the file relative to a
@@ -22,7 +21,7 @@ func (f *FilePath) Path() string {
 func (f *FilePath) Reparent(old, new string) error {
 	if filepath.IsAbs(f.path) != filepath.IsAbs(old) ||
 		filepath.IsAbs(old) != filepath.IsAbs(new) {
-		return errors.Errorf("relative path / absolute path mismatch: %s %s %s", f.path, old, new)
+		return fmt.Errorf("relative path / absolute path mismatch: %s %s %s", f.path, old, new)
 	}
 
 	relPath, err := filepath.Rel(old, f.path)
@@ -30,7 +29,7 @@ func (f *FilePath) Reparent(old, new string) error {
 		return err
 	}
 	if strings.HasPrefix(relPath, "..") {
-		return errors.Errorf("old is not a prefix of path")
+		return fmt.Errorf("old is not a prefix of path")
 	}
 
 	f.path = filepath.Join(new, relPath)

--- a/constraint/pkg/regorewriter/module.go
+++ b/constraint/pkg/regorewriter/module.go
@@ -22,7 +22,7 @@ func (m *Module) Write() error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(m.Path(), b, 0600)
+	return ioutil.WriteFile(m.Path(), b, 0o600)
 }
 
 // Content returns the module as a byte slice of rego source code.

--- a/constraint/pkg/regorewriter/module.go
+++ b/constraint/pkg/regorewriter/module.go
@@ -8,7 +8,7 @@ import (
 	"github.com/open-policy-agent/opa/format"
 )
 
-// Module represents a rego module
+// Module represents a rego module.
 type Module struct {
 	FilePath
 
@@ -22,7 +22,7 @@ func (m *Module) Write() error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(m.Path(), b, 0640)
+	return ioutil.WriteFile(m.Path(), b, 0600)
 }
 
 // Content returns the module as a byte slice of rego source code.

--- a/constraint/pkg/regorewriter/packagetransformer.go
+++ b/constraint/pkg/regorewriter/packagetransformer.go
@@ -21,14 +21,14 @@ type PackagePrefixer struct {
 	prefix []string
 }
 
-// NewPackagePrefixer returns a new PackagePrefixer
+// NewPackagePrefixer returns a new PackagePrefixer.
 func NewPackagePrefixer(pkgPrefix string) *PackagePrefixer {
 	return &PackagePrefixer{
 		prefix: strings.Split(pkgPrefix, "."),
 	}
 }
 
-// Transform implements PackageTransformer
+// Transform implements PackageTransformer.
 func (p *PackagePrefixer) Transform(ref ast.Ref) ast.Ref {
 	var newRef ast.Ref
 	newRef = append(newRef, ref[0])

--- a/constraint/pkg/regorewriter/packagetransformer_test.go
+++ b/constraint/pkg/regorewriter/packagetransformer_test.go
@@ -44,7 +44,6 @@ func TestPackagePrefixer(t *testing.T) {
 			if !wantRef.Equal(gotRef) {
 				t.Errorf("wanted %s, got %s", wantRef, gotRef)
 			}
-
 		})
 	}
 }

--- a/constraint/pkg/regorewriter/regorewriter.go
+++ b/constraint/pkg/regorewriter/regorewriter.go
@@ -11,7 +11,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/format"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -47,11 +46,11 @@ type RegoRewriter struct {
 func New(pt PackageTransformer, libs []string, externs []string) (*RegoRewriter, error) {
 	externRefs, err := packagesAsRefs(externs)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to parse externs")
+		return nil, fmt.Errorf("failed to parse externs: %w", err)
 	}
 	libRefs, err := packagesAsRefs(libs)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to parse libs")
+		return nil, fmt.Errorf("failed to parse libs: %w", err)
 	}
 
 	return &RegoRewriter{
@@ -96,7 +95,7 @@ func (r *RegoRewriter) addTestDir(testDirPath string) error {
 	glog.V(vLog).Infof("Walking test dir %s", testDirPath)
 	walkFn := func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			return errors.Wrapf(err, "walk error on path %s", path)
+			return fmt.Errorf("walk error on path %s: %w", path, err)
 		}
 		if info.IsDir() {
 			return nil
@@ -313,7 +312,7 @@ func (r *RegoRewriter) checkDataReferences() error {
 			})
 		}
 		if errs != nil {
-			return errors.Wrapf(errs, "check refs failed on module %s", m.FilePath)
+			return fmt.Errorf("check refs failed on module %s: %w", m.FilePath, errs)
 		}
 		return nil
 	})

--- a/constraint/pkg/regorewriter/regorewriter.go
+++ b/constraint/pkg/regorewriter/regorewriter.go
@@ -1,6 +1,7 @@
 package regorewriter
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -13,8 +14,10 @@ import (
 	"github.com/pkg/errors"
 )
 
-const vLog = 2
-const vLogDetail = vLog + 1
+const (
+	vLog       = 2
+	vLogDetail = vLog + 1
+)
 
 // RegoRewriter rewrites rego code by updating library package paths by prepending a prefix
 // and updating references to library code accordingly.
@@ -111,17 +114,15 @@ func (r *RegoRewriter) addTestDir(testDirPath string) error {
 		r.testData = append(r.testData, &TestData{FilePath: FilePath{path: path}, content: bytes})
 		return nil
 	}
-	if err := filepath.Walk(testDirPath, walkFn); err != nil {
-		return err
-	}
-	return nil
+
+	return filepath.Walk(testDirPath, walkFn)
 }
 
 // addFileFromFs reads a file from the filesystem, parses it then appends it to slice.
 func (r *RegoRewriter) addFileFromFs(path string, slice *[]*Module) error {
 	glog.V(vLog).Infof("adding file %s", path)
 	if !strings.HasSuffix(path, ".rego") {
-		return errors.Errorf("invalid file specified %s", path)
+		return fmt.Errorf("invalid file specified %s", path)
 	}
 
 	bytes, err := ioutil.ReadFile(path)
@@ -166,10 +167,8 @@ func (r *RegoRewriter) addPathFromFs(path string, slice *[]*Module) error {
 			}
 			return r.addFileFromFs(path, slice)
 		}
-		if err := filepath.Walk(path, walkFn); err != nil {
-			return err
-		}
-		return nil
+
+		return filepath.Walk(path, walkFn)
 	}
 
 	return r.addFileFromFs(path, slice)
@@ -186,7 +185,7 @@ func (r *RegoRewriter) AddLibFromFs(path string) error {
 	return r.addPathFromFs(path, &r.libs)
 }
 
-// forAllModules runs f on all rego modules (both entrypoints and libraries)
+// forAllModules runs f on all rego modules (both entrypoints and libraries).
 func (r *RegoRewriter) forAllModules(f func(*Module) error) error {
 	for _, m := range r.libs {
 		if err := f(m); err != nil {
@@ -225,7 +224,7 @@ func (r *RegoRewriter) checkLibPackages() error {
 	for _, mod := range r.libs {
 		path := mod.Module.Package.Path
 		if !r.allowedLibPackage(path) {
-			return errors.Errorf("path %s not found in lib prefixes", path)
+			return fmt.Errorf("path %s not found in lib prefixes", path)
 		}
 	}
 	return nil
@@ -267,7 +266,7 @@ func (r *RegoRewriter) checkRef(ref ast.Ref) error {
 		}
 	}
 
-	return errors.Errorf("disallowed ref %s", ref)
+	return fmt.Errorf("disallowed ref %s", ref)
 }
 
 // checkImport checks the import statement to ensure that it's a subref of an allowed lib prefix.
@@ -275,9 +274,13 @@ func (r *RegoRewriter) checkImport(i *ast.Import) error {
 	want := i.Path.String()
 	glog.V(vLog).Infof("checking import %s", want)
 
-	importRef := i.Path.Value.(ast.Ref)
+	importRef, ok := i.Path.Value.(ast.Ref)
+	if !ok {
+		return fmt.Errorf("got reference of type %T, want %T", i.Path.Value, ast.Ref{})
+	}
+
 	if isSubRef(inputRefPrefix, importRef) {
-		return errors.Errorf("bad import")
+		return fmt.Errorf("bad import")
 	}
 
 	for _, libPrefix := range r.allowedLibPrefixes {
@@ -286,7 +289,7 @@ func (r *RegoRewriter) checkImport(i *ast.Import) error {
 		}
 	}
 
-	return errors.Errorf("bad import")
+	return fmt.Errorf("bad import")
 }
 
 // checkDataReferences checks that all data references are directed to allowed lib prefixes or
@@ -354,12 +357,17 @@ func (r *RegoRewriter) rewriteDataRef(ref ast.Ref) ast.Ref {
 }
 
 // rewriteImportPath updates an import path to the new value.
-func (r *RegoRewriter) rewriteImportPath(path *ast.Term) *ast.Term {
-	pathRef := path.Value.(ast.Ref)
-	if !r.refNeedsRewrite(pathRef) {
-		return path
+func (r *RegoRewriter) rewriteImportPath(path *ast.Term) (*ast.Term, error) {
+	pathRef, ok := path.Value.(ast.Ref)
+	if !ok {
+		return nil, fmt.Errorf("got reference of type %T, want %T", path.Value, ast.Ref{})
 	}
-	return ast.NewTerm(r.rewriteDataRef(pathRef))
+
+	if !r.refNeedsRewrite(pathRef) {
+		return path, nil
+	}
+
+	return ast.NewTerm(r.rewriteDataRef(pathRef)), nil
 }
 
 // Rewrite will check the input source and update the package paths and refs as appropriate.
@@ -380,7 +388,11 @@ func (r *RegoRewriter) Rewrite() (*Sources, error) {
 			for _, t := range i.Path.Value.(ast.Ref) {
 				glog.V(vLogDetail).Infof("  term: %s %#v %#v", t, t, reflect.TypeOf(t.Value).String())
 			}
-			i.Path = r.rewriteImportPath(i.Path)
+			var err error
+			i.Path, err = r.rewriteImportPath(i.Path)
+			if err != nil {
+				return err
+			}
 		}
 
 		for _, rule := range mod.Module.Rules {

--- a/constraint/pkg/regorewriter/sources.go
+++ b/constraint/pkg/regorewriter/sources.go
@@ -47,7 +47,7 @@ func (s *Sources) allSources() []sourceFile {
 	return m
 }
 
-// ForEachModule applys fn to each EntryPoint and Lib.
+// ForEachModule applies fn to each EntryPoint and Lib.
 func (s *Sources) ForEachModule(fn func(m *Module) error) error {
 	for _, module := range s.EntryPoints {
 		if err := fn(module); err != nil {
@@ -91,8 +91,8 @@ func (s *Sources) Reparent(old, new string) error {
 
 // Write will write the sources to the filesystem.
 func (s *Sources) Write() error {
-	// TODO: Determine if _unused is intended to be used in anything.
-	return s.forAll(func(_unused sourceFile) error {
+	// TODO: Determine if _ is intended to be used in anything.
+	return s.forAll(func(_ sourceFile) error {
 		for _, module := range s.allSources() {
 			path := module.Path()
 			content, err := module.Content()

--- a/constraint/pkg/regorewriter/sources.go
+++ b/constraint/pkg/regorewriter/sources.go
@@ -8,7 +8,7 @@ import (
 	"github.com/golang/glog"
 )
 
-// Sources represents all modules that have been fed into the
+// Sources represents all modules that have been fed into the.
 type Sources struct {
 	// EntryPoints are the sources which contain the constraint template violation rule.
 	EntryPoints []*Module
@@ -47,7 +47,7 @@ func (s *Sources) allSources() []sourceFile {
 	return m
 }
 
-// ForEachModule applys fn to each EntryPoint and Lib
+// ForEachModule applys fn to each EntryPoint and Lib.
 func (s *Sources) ForEachModule(fn func(m *Module) error) error {
 	for _, module := range s.EntryPoints {
 		if err := fn(module); err != nil {
@@ -91,18 +91,19 @@ func (s *Sources) Reparent(old, new string) error {
 
 // Write will write the sources to the filesystem.
 func (s *Sources) Write() error {
-	return s.forAll(func(module sourceFile) error {
+	// TODO: Determine if _unused is intended to be used in anything.
+	return s.forAll(func(_unused sourceFile) error {
 		for _, module := range s.allSources() {
 			path := module.Path()
 			content, err := module.Content()
 			if err != nil {
 				return err
 			}
-			if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
+			if err = os.MkdirAll(filepath.Dir(path), 0750); err != nil {
 				return err
 			}
 			glog.Infof("Writing %s", path)
-			if err := ioutil.WriteFile(path, content, 0640); err != nil {
+			if err = ioutil.WriteFile(path, content, 0600); err != nil {
 				return err
 			}
 		}

--- a/constraint/pkg/regorewriter/sources.go
+++ b/constraint/pkg/regorewriter/sources.go
@@ -99,11 +99,11 @@ func (s *Sources) Write() error {
 			if err != nil {
 				return err
 			}
-			if err = os.MkdirAll(filepath.Dir(path), 0750); err != nil {
+			if err = os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 				return err
 			}
 			glog.Infof("Writing %s", path)
-			if err = ioutil.WriteFile(path, content, 0600); err != nil {
+			if err = ioutil.WriteFile(path, content, 0o600); err != nil {
 				return err
 			}
 		}

--- a/constraint/pkg/regorewriter/testdata.go
+++ b/constraint/pkg/regorewriter/testdata.go
@@ -7,7 +7,7 @@ type TestData struct {
 	content []byte
 }
 
-// Content implements sourceFile
+// Content implements sourceFile.
 func (t *TestData) Content() ([]byte, error) {
 	return t.content, nil
 }

--- a/constraint/pkg/types/validation.go
+++ b/constraint/pkg/types/validation.go
@@ -36,19 +36,19 @@ type Response struct {
 
 func (r *Response) TraceDump() string {
 	b := &strings.Builder{}
-	fmt.Fprintf(b, "Target: %s\n", r.Target)
+	_, _ = fmt.Fprintf(b, "Target: %s\n", r.Target)
 	if r.Input == nil {
-		fmt.Fprintf(b, "Input: TRACING DISABLED\n\n")
+		_, _ = fmt.Fprintf(b, "Input: TRACING DISABLED\n\n")
 	} else {
-		fmt.Fprintf(b, "Input:\n%s\n\n", *r.Input)
+		_, _ = fmt.Fprintf(b, "Input:\n%s\n\n", *r.Input)
 	}
 	if r.Trace == nil {
-		fmt.Fprintf(b, "Trace: TRACING DISABLED\n\n")
+		_, _ = fmt.Fprintf(b, "Trace: TRACING DISABLED\n\n")
 	} else {
-		fmt.Fprintf(b, "Trace:\n%s\n\n", *r.Trace)
+		_, _ = fmt.Fprintf(b, "Trace:\n%s\n\n", *r.Trace)
 	}
-	for i, r := range r.Results {
-		fmt.Fprintf(b, "Result(%d):\n%s\n\n", i, spew.Sdump(r))
+	for i, result := range r.Results {
+		_, _ = fmt.Fprintf(b, "Result(%d):\n%s\n\n", i, spew.Sdump(result))
 	}
 	return b.String()
 }
@@ -92,8 +92,8 @@ func (r *Responses) HandledCount() int {
 func (r *Responses) TraceDump() string {
 	b := &strings.Builder{}
 	for _, resp := range r.ByTarget {
-		fmt.Fprintln(b, resp.TraceDump())
-		fmt.Fprintln(b, "")
+		_, _ = fmt.Fprintln(b, resp.TraceDump())
+		_, _ = fmt.Fprintln(b, "")
 	}
 	return b.String()
 }


### PR DESCRIPTION
Use the same linters we use in gatekeeper/ for consistency.

Remove usage of deprecated/now-unsupported linters.

Make changes to make linting pass.

Signed-off-by: Will Beason <willbeason@google.com>