### PR TITLE
Add benchmarks for client.AddTemplate

### DIFF
--- a/constraint/pkg/client/client_addtemplate_bench_test.go
+++ b/constraint/pkg/client/client_addtemplate_bench_test.go
@@ -1,0 +1,108 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/open-policy-agent/frameworks/constraint/pkg/client/drivers/local"
+	"github.com/open-policy-agent/frameworks/constraint/pkg/core/templates"
+)
+
+var nTemplates = []int{1, 2, 5, 10, 20, 50, 100, 200}
+
+func makeKind(i int) string {
+	return fmt.Sprintf("foo%d", i)
+}
+
+func makeModuleSimple(i int) string {
+	kind := makeKind(i)
+	return fmt.Sprintf(`package %s
+violation[msg] {
+  input.review.object.foo == input.parameters.foo
+  msg := sprintf("input.foo is %%v", [input.parameters.foo])
+}`, kind)
+}
+
+func makeModuleComplex(i int) string {
+	kind := makeKind(i)
+	return fmt.Sprintf(`package %s
+
+identical(obj, review) {
+  obj.metadata.namespace == review.object.metadata.namespace
+  obj.metadata.name == review.object.metadata.name
+}
+violation[{"msg": msg}] {
+  input.review.kind.kind == "Ingress"
+  re_match("^(extensions|networking.k8s.io)$", input.review.kind.group)
+  host := input.review.object.spec.rules[_].host
+  other := data.inventory.namespace[ns][otherapiversion]["Ingress"][name]
+  re_match("^(extensions|networking.k8s.io)/.+$", otherapiversion)
+  other.spec.rules[_].host == host
+  not identical(other, input.review)
+  msg := sprintf("Ingress host conflicts with an existing Ingress <%%v>", [host])
+}`, kind)
+}
+
+func makeConstraintTemplate(i int, makeModule func(i int) string) *templates.ConstraintTemplate {
+	kind := makeKind(i)
+	ct := &templates.ConstraintTemplate{}
+	ct.SetName(kind)
+	ct.Spec.CRD.Spec.Names.Kind = kind
+	ct.Spec.Targets = []templates.Target{{
+		Target: "test.target",
+		Rego:   makeModule(i),
+	}}
+
+	return ct
+}
+
+func BenchmarkClient_AddTemplate(b *testing.B) {
+	modules := []struct {
+		name       string
+		makeModule func(i int) string
+	}{{
+		name:       "Simple",
+		makeModule: makeModuleSimple,
+	}, {
+		name:       "Complex",
+		makeModule: makeModuleComplex,
+	}}
+
+	for _, tc := range modules {
+		b.Run(tc.name, func(b *testing.B) {
+			for _, n := range nTemplates {
+				b.Run(fmt.Sprintf("%d Templates", n), func(b *testing.B) {
+					cts := make([]*templates.ConstraintTemplate, n)
+					for i := range cts {
+						cts[i] = makeConstraintTemplate(i, tc.makeModule)
+					}
+
+					for i := 0; i < b.N; i++ {
+						b.StopTimer()
+						ctx := context.Background()
+						targets := Targets(&handler{})
+
+						d := local.New()
+
+						backend, err := NewBackend(Driver(d))
+						if err != nil {
+							b.Fatal(err)
+						}
+
+						c, err := backend.NewClient(targets)
+						if err != nil {
+							b.Fatal(err)
+						}
+
+						b.StartTimer()
+
+						for _, ct := range cts {
+							_, _ = c.AddTemplate(ctx, ct)
+						}
+					}
+				})
+			}
+		})
+	}
+}

--- a/constraint/pkg/client/client_addtemplate_bench_test.go
+++ b/constraint/pkg/client/client_addtemplate_bench_test.go
@@ -9,7 +9,20 @@ import (
 	"github.com/open-policy-agent/frameworks/constraint/pkg/core/templates"
 )
 
-var nTemplates = []int{1, 2, 5, 10, 20, 50, 100, 200}
+var (
+	nTemplates = []int{1, 2, 5, 10, 20, 50, 100, 200}
+
+	modules = []struct {
+		name       string
+		makeModule func(i int) string
+	}{{
+		name:       "Simple",
+		makeModule: makeModuleSimple,
+	}, {
+		name:       "Complex",
+		makeModule: makeModuleComplex,
+	}}
+)
 
 func makeKind(i int) string {
 	return fmt.Sprintf("foo%d", i)
@@ -58,17 +71,6 @@ func makeConstraintTemplate(i int, makeModule func(i int) string) *templates.Con
 }
 
 func BenchmarkClient_AddTemplate(b *testing.B) {
-	modules := []struct {
-		name       string
-		makeModule func(i int) string
-	}{{
-		name:       "Simple",
-		makeModule: makeModuleSimple,
-	}, {
-		name:       "Complex",
-		makeModule: makeModuleComplex,
-	}}
-
 	for _, tc := range modules {
 		b.Run(tc.name, func(b *testing.B) {
 			for _, n := range nTemplates {


### PR DESCRIPTION
Add benchmarks for client.AddTemplate for a simple ConstraintTemplate and a complex one. The complex ConstraintTemplate is a copy of [UniqueIngressHost](https://github.com/open-policy-agent/gatekeeper-library/blob/master/library/general/uniqueingresshost/template.yaml). It's okay if this falls out of sync with the ConstraintTemplate it's based on - what matters is having a complex CT, not that it exactly matches one.

```
constraint$ go test ./pkg/client --bench=. --benchmem
goos: linux
goarch: amd64
pkg: github.com/open-policy-agent/frameworks/constraint/pkg/client
cpu: Intel(R) Xeon(R) W-2135 CPU @ 3.70GHz
BenchmarkClient_AddTemplate/Simple/1_Templates-12         	     129	   9058282 ns/op	 1200880 B/op	   23595 allocs/op
BenchmarkClient_AddTemplate/Simple/2_Templates-12         	      61	  17941913 ns/op	 2379309 B/op	   47185 allocs/op
BenchmarkClient_AddTemplate/Simple/5_Templates-12         	      25	  46099557 ns/op	 5940319 B/op	  117951 allocs/op
BenchmarkClient_AddTemplate/Simple/10_Templates-12        	      12	  90045892 ns/op	11881112 B/op	  235928 allocs/op
BenchmarkClient_AddTemplate/Simple/20_Templates-12        	       6	 182456681 ns/op	23753468 B/op	  471812 allocs/op
BenchmarkClient_AddTemplate/Simple/50_Templates-12        	       3	 457135641 ns/op	59113586 B/op	 1179453 allocs/op
BenchmarkClient_AddTemplate/Simple/100_Templates-12       	       2	 915068659 ns/op	118516644 B/op	 2359408 allocs/op
BenchmarkClient_AddTemplate/Simple/200_Templates-12       	       1	1703187888 ns/op	236725560 B/op	 4719088 allocs/op
BenchmarkClient_AddTemplate/Complex/1_Templates-12        	      97	  10802338 ns/op	 1390259 B/op	   28547 allocs/op
BenchmarkClient_AddTemplate/Complex/2_Templates-12        	      46	  22915279 ns/op	 2877124 B/op	   60237 allocs/op
BenchmarkClient_AddTemplate/Complex/5_Templates-12        	      16	  63753467 ns/op	 8055650 B/op	  174220 allocs/op
BenchmarkClient_AddTemplate/Complex/10_Templates-12       	       8	 149904414 ns/op	18973611 B/op	  427264 allocs/op
BenchmarkClient_AddTemplate/Complex/20_Templates-12       	       3	 385724089 ns/op	49822754 B/op	 1170057 allocs/op
BenchmarkClient_AddTemplate/Complex/50_Templates-12       	       1	1471954431 ns/op	211890088 B/op	 5291328 allocs/op
BenchmarkClient_AddTemplate/Complex/100_Templates-12      	       1	4261518166 ns/op	715699320 B/op	18469732 allocs/op
BenchmarkClient_AddTemplate/Complex/200_Templates-12      	       1	13000580510 ns/op	2596388776 B/op	68489749 allocs/op

```

Fixes #151

Signed-off-by: Will Beason <willbeason@google.com>