### PR TITLE
Go113errors

### DIFF
--- a/constraint/pkg/apis/templates/v1/constrainttemplate_types_test.go
+++ b/constraint/pkg/apis/templates/v1/constrainttemplate_types_test.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
 )
 
 func TestStorageConstraintTemplate(t *testing.T) {
@@ -144,8 +145,6 @@ func TestValidationVersionConversionAndTransformation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	trueBool := true
-	falseBool := false
 	testCases := []struct {
 		name string
 		v    *Validation
@@ -154,22 +153,22 @@ func TestValidationVersionConversionAndTransformation(t *testing.T) {
 		{
 			name: "Two deep properties, LegacySchema=true",
 			v: &Validation{
-				LegacySchema:    &trueBool,
+				LegacySchema:    pointer.Bool(true),
 				OpenAPIV3Schema: schema.VersionedIncompleteSchema(),
 			},
 			exp: &templates.Validation{
-				LegacySchema:    &trueBool,
+				LegacySchema:    pointer.Bool(true),
 				OpenAPIV3Schema: schema.VersionlessSchemaWithXPreserve(),
 			},
 		},
 		{
 			name: "Two deep properties, LegacySchema=false",
 			v: &Validation{
-				LegacySchema:    &falseBool,
+				LegacySchema:    pointer.Bool(false),
 				OpenAPIV3Schema: schema.VersionedIncompleteSchema(),
 			},
 			exp: &templates.Validation{
-				LegacySchema:    &falseBool,
+				LegacySchema:    pointer.Bool(false),
 				OpenAPIV3Schema: schema.VersionlessSchema(),
 			},
 		},
@@ -185,24 +184,24 @@ func TestValidationVersionConversionAndTransformation(t *testing.T) {
 		{
 			name: "Nil properties, LegacySchema=true",
 			v: &Validation{
-				LegacySchema:    &trueBool,
+				LegacySchema:    pointer.Bool(true),
 				OpenAPIV3Schema: nil,
 			},
 			exp: &templates.Validation{
-				LegacySchema: &trueBool,
+				LegacySchema: pointer.Bool(true),
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
-					XPreserveUnknownFields: &trueBool,
+					XPreserveUnknownFields: pointer.Bool(true),
 				},
 			},
 		},
 		{
 			name: "Nil properties, LegacySchema=false",
 			v: &Validation{
-				LegacySchema:    &falseBool,
+				LegacySchema:    pointer.Bool(false),
 				OpenAPIV3Schema: nil,
 			},
 			exp: &templates.Validation{
-				LegacySchema:    &falseBool,
+				LegacySchema:    pointer.Bool(false),
 				OpenAPIV3Schema: nil,
 			},
 		},

--- a/constraint/pkg/apis/templates/v1alpha1/constrainttemplate_types_test.go
+++ b/constraint/pkg/apis/templates/v1alpha1/constrainttemplate_types_test.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
 )
 
 func TestStorageConstraintTemplate(t *testing.T) {
@@ -139,8 +140,6 @@ func TestValidationVersionConversionAndTransformation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	trueBool := true
-	falseBool := false
 	testCases := []struct {
 		name string
 		v    *Validation
@@ -149,22 +148,22 @@ func TestValidationVersionConversionAndTransformation(t *testing.T) {
 		{
 			name: "Two deep properties, LegacySchema=true",
 			v: &Validation{
-				LegacySchema:    &trueBool,
+				LegacySchema:    pointer.Bool(true),
 				OpenAPIV3Schema: schema.VersionedIncompleteSchema(),
 			},
 			exp: &templates.Validation{
-				LegacySchema:    &trueBool,
+				LegacySchema:    pointer.Bool(true),
 				OpenAPIV3Schema: schema.VersionlessSchemaWithXPreserve(),
 			},
 		},
 		{
 			name: "Two deep properties, LegacySchema=false",
 			v: &Validation{
-				LegacySchema:    &falseBool,
+				LegacySchema:    pointer.Bool(false),
 				OpenAPIV3Schema: schema.VersionedIncompleteSchema(),
 			},
 			exp: &templates.Validation{
-				LegacySchema:    &falseBool,
+				LegacySchema:    pointer.Bool(false),
 				OpenAPIV3Schema: schema.VersionlessSchema(),
 			},
 		},
@@ -180,24 +179,24 @@ func TestValidationVersionConversionAndTransformation(t *testing.T) {
 		{
 			name: "Nil properties, LegacySchema=true",
 			v: &Validation{
-				LegacySchema:    &trueBool,
+				LegacySchema:    pointer.Bool(true),
 				OpenAPIV3Schema: nil,
 			},
 			exp: &templates.Validation{
-				LegacySchema: &trueBool,
+				LegacySchema: pointer.Bool(true),
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
-					XPreserveUnknownFields: &trueBool,
+					XPreserveUnknownFields: pointer.Bool(true),
 				},
 			},
 		},
 		{
 			name: "Nil properties, LegacySchema=false",
 			v: &Validation{
-				LegacySchema:    &falseBool,
+				LegacySchema:    pointer.Bool(false),
 				OpenAPIV3Schema: nil,
 			},
 			exp: &templates.Validation{
-				LegacySchema:    &falseBool,
+				LegacySchema:    pointer.Bool(false),
 				OpenAPIV3Schema: nil,
 			},
 		},

--- a/constraint/pkg/apis/templates/v1beta1/constrainttemplate_types_test.go
+++ b/constraint/pkg/apis/templates/v1beta1/constrainttemplate_types_test.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
 )
 
 func TestStorageConstraintTemplate(t *testing.T) {
@@ -138,8 +139,6 @@ func TestValidationVersionConversionAndTransformation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	trueBool := true
-	falseBool := false
 	testCases := []struct {
 		name string
 		v    *Validation
@@ -148,22 +147,22 @@ func TestValidationVersionConversionAndTransformation(t *testing.T) {
 		{
 			name: "Two deep properties, LegacySchema=true",
 			v: &Validation{
-				LegacySchema:    &trueBool,
+				LegacySchema:    pointer.Bool(true),
 				OpenAPIV3Schema: schema.VersionedIncompleteSchema(),
 			},
 			exp: &templates.Validation{
-				LegacySchema:    &trueBool,
+				LegacySchema:    pointer.Bool(true),
 				OpenAPIV3Schema: schema.VersionlessSchemaWithXPreserve(),
 			},
 		},
 		{
 			name: "Two deep properties, LegacySchema=false",
 			v: &Validation{
-				LegacySchema:    &falseBool,
+				LegacySchema:    pointer.Bool(false),
 				OpenAPIV3Schema: schema.VersionedIncompleteSchema(),
 			},
 			exp: &templates.Validation{
-				LegacySchema:    &falseBool,
+				LegacySchema:    pointer.Bool(false),
 				OpenAPIV3Schema: schema.VersionlessSchema(),
 			},
 		},
@@ -179,24 +178,24 @@ func TestValidationVersionConversionAndTransformation(t *testing.T) {
 		{
 			name: "Nil properties, LegacySchema=true",
 			v: &Validation{
-				LegacySchema:    &trueBool,
+				LegacySchema:    pointer.Bool(true),
 				OpenAPIV3Schema: nil,
 			},
 			exp: &templates.Validation{
-				LegacySchema: &trueBool,
+				LegacySchema: pointer.Bool(true),
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
-					XPreserveUnknownFields: &trueBool,
+					XPreserveUnknownFields: pointer.Bool(true),
 				},
 			},
 		},
 		{
 			name: "Nil properties, LegacySchema=false",
 			v: &Validation{
-				LegacySchema:    &falseBool,
+				LegacySchema:    pointer.Bool(false),
 				OpenAPIV3Schema: nil,
 			},
 			exp: &templates.Validation{
-				LegacySchema:    &falseBool,
+				LegacySchema:    pointer.Bool(false),
 				OpenAPIV3Schema: nil,
 			},
 		},

--- a/constraint/pkg/client/backend.go
+++ b/constraint/pkg/client/backend.go
@@ -88,5 +88,7 @@ func (b *Backend) NewClient(opts ...Opt) (*Client, error) {
 	if err := c.init(); err != nil {
 		return nil, err
 	}
+
+	b.hasClient = true
 	return c, nil
 }

--- a/constraint/pkg/client/backend.go
+++ b/constraint/pkg/client/backend.go
@@ -23,8 +23,10 @@ func Driver(d drivers.Driver) BackendOpt {
 	}
 }
 
-// NewBackend creates a new backend. A backend could be a connection to a remote server or
-// a new local OPA instance.
+// NewBackend creates a new backend. A backend could be a connection to a remote
+// server or a new local OPA instance.
+//
+// A BackendOpt setting driver, such as Driver() must be passed.
 func NewBackend(opts ...BackendOpt) (*Backend, error) {
 	helper, err := newCRDHelper()
 	if err != nil {

--- a/constraint/pkg/client/backend.go
+++ b/constraint/pkg/client/backend.go
@@ -36,7 +36,7 @@ func NewBackend(opts ...BackendOpt) (*Backend, error) {
 	}
 
 	if b.driver == nil {
-		return nil, fmt.Errorf("%w: no driver supplied", errCreatingBackend)
+		return nil, fmt.Errorf("%w: no driver supplied", ErrCreatingBackend)
 	}
 
 	return b, nil
@@ -46,7 +46,7 @@ func NewBackend(opts ...BackendOpt) (*Backend, error) {
 func (b *Backend) NewClient(opts ...Opt) (*Client, error) {
 	if b.hasClient {
 		return nil, fmt.Errorf("%w: only one client per backend is allowed",
-			errCreatingClient)
+			ErrCreatingClient)
 	}
 
 	var fields []string
@@ -70,13 +70,13 @@ func (b *Backend) NewClient(opts ...Opt) (*Client, error) {
 	for _, field := range c.allowedDataFields {
 		if !validDataFields[field] {
 			return nil, fmt.Errorf("%w: invalid data field %q; allowed fields are: %v",
-				errCreatingClient, field, validDataFields)
+				ErrCreatingClient, field, validDataFields)
 		}
 	}
 
 	if len(c.targets) == 0 {
 		return nil, fmt.Errorf("%w: must specify at least one target with client.Targets",
-			errCreatingClient)
+			ErrCreatingClient)
 	}
 
 	if err := b.driver.Init(context.Background()); err != nil {

--- a/constraint/pkg/client/backend_test.go
+++ b/constraint/pkg/client/backend_test.go
@@ -36,3 +36,61 @@ func TestNewBackend(t *testing.T) {
 		})
 	}
 }
+
+func TestBackend_NewClient(t *testing.T) {
+	testCases := []struct {
+		name        string
+		backendOpts []BackendOpt
+		clientOpts  []Opt
+		wantError   error
+	}{
+		{
+			name:        "no opts",
+			backendOpts: nil,
+			clientOpts:  nil,
+			wantError:   ErrCreatingClient,
+		},
+		{
+			name:        "with handler",
+			backendOpts: nil,
+			clientOpts:  []Opt{Targets(&handler{})},
+			wantError:   nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := []BackendOpt{Driver(local.New())}
+			opts = append(opts, tc.backendOpts...)
+
+			backend, err := NewBackend(opts...)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			_, err = backend.NewClient(tc.clientOpts...)
+			if !errors.Is(err, tc.wantError) {
+				t.Fatalf("got NewClient() eror = %v, want %v",
+					err, tc.wantError)
+			}
+		})
+	}
+}
+
+func TestBackend_NewClient2(t *testing.T) {
+	backend, err := NewBackend(Driver(local.New()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = backend.NewClient(Targets(&handler{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = backend.NewClient(Targets(&handler{}))
+	if !errors.Is(err, ErrCreatingClient) {
+		t.Fatalf("got NewClient() err = %v, want %v",
+			err, ErrCreatingClient)
+	}
+}

--- a/constraint/pkg/client/backend_test.go
+++ b/constraint/pkg/client/backend_test.go
@@ -1,0 +1,38 @@
+package client
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/open-policy-agent/frameworks/constraint/pkg/client/drivers/local"
+)
+
+func TestNewBackend(t *testing.T) {
+	testCases := []struct {
+		name      string
+		opts      []BackendOpt
+		wantError error
+	}{
+		{
+			name:      "no args",
+			opts:      nil,
+			wantError: ErrCreatingBackend,
+		},
+		{
+			name:      "good",
+			opts:      []BackendOpt{Driver(local.New())},
+			wantError: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, gotErr := NewBackend(tc.opts...)
+
+			if !errors.Is(gotErr, tc.wantError) {
+				t.Fatalf("got NewBackent() error = %v, want %v",
+					gotErr, tc.wantError)
+			}
+		})
+	}
+}

--- a/constraint/pkg/client/client.go
+++ b/constraint/pkg/client/client.go
@@ -32,13 +32,13 @@ type templateEntry struct {
 }
 
 type Client struct {
-	backend           *Backend
-	targets           map[string]TargetHandler
+	backend *Backend
+	targets map[string]TargetHandler
 
 	// mtx guards access to both templates and constraints.
-	mtx       sync.RWMutex
-	templates map[templateKey]*templateEntry
-	constraints       map[schema.GroupKind]map[string]*unstructured.Unstructured
+	mtx         sync.RWMutex
+	templates   map[templateKey]*templateEntry
+	constraints map[schema.GroupKind]map[string]*unstructured.Unstructured
 
 	allowedDataFields []string
 }

--- a/constraint/pkg/client/client.go
+++ b/constraint/pkg/client/client.go
@@ -744,7 +744,7 @@ func (c *Client) init() error {
 				ErrCreatingClient, err)
 		}
 
-		err = c.backend.driver.PutModule(ctx, modulePath, string(src))
+		err = c.backend.driver.PutModule(context.TODO(), modulePath, string(src))
 		if err != nil {
 			return fmt.Errorf("%w: error %s from compiled source:\n%s",
 				ErrCreatingClient, err, src)

--- a/constraint/pkg/client/client.go
+++ b/constraint/pkg/client/client.go
@@ -125,13 +125,9 @@ func (c *Client) validateTargets(templ *templates.ConstraintTemplate) (*template
 	targetSpec := &templ.Spec.Targets[0]
 	targetHandler, found := c.targets[targetSpec.Target]
 
-	var knownTargets []string
-	for known := range c.targets {
-		knownTargets = append(knownTargets, known)
-	}
-	sort.Strings(knownTargets)
-
 	if !found {
+		knownTargets := c.knownTargets()
+
 		return nil, nil, fmt.Errorf("%w: target %s not recognized, known targets %v",
 			ErrInvalidConstraintTemplate, targetSpec.Target, knownTargets)
 	}
@@ -861,4 +857,15 @@ TargetLoop:
 // Dump dumps the state of OPA to aid in debugging.
 func (c *Client) Dump(ctx context.Context) (string, error) {
 	return c.backend.driver.Dump(ctx)
+}
+
+// knownTargets returns a sorted list of currently-known target names.
+func (c *Client) knownTargets() []string {
+	var knownTargets []string
+	for known := range c.targets {
+		knownTargets = append(knownTargets, known)
+	}
+	sort.Strings(knownTargets)
+
+	return knownTargets
 }

--- a/constraint/pkg/client/client_opts.go
+++ b/constraint/pkg/client/client_opts.go
@@ -1,0 +1,59 @@
+package client
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+)
+
+type Opt func(*Client) error
+
+// targetNameRegex defines allowable target names.
+// Does not match empty string.
+var targetNameRegex = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9.]*$`)
+
+// Targets defines the targets Client will pass review requests to.
+func Targets(ts ...TargetHandler) Opt {
+	return func(c *Client) error {
+		handlers := make(map[string]TargetHandler, len(ts))
+
+		invalid := validateTargetNames(ts)
+		if len(invalid) > 0 {
+			return fmt.Errorf("%w: target names %v are not of the form %q",
+				errCreatingClient, invalid, targetNameRegex.String())
+		}
+
+		for _, t := range ts {
+			handlers[t.GetName()] = t
+		}
+		c.targets = handlers
+
+		return nil
+	}
+}
+
+// validateTargetNames returns the invalid target names from the passed
+// TargetHandlers.
+func validateTargetNames(ts []TargetHandler) []string {
+	var invalid []string
+
+	for _, t := range ts {
+		name := t.GetName()
+		if !targetNameRegex.MatchString(name) {
+			invalid = append(invalid, name)
+		}
+	}
+	sort.Strings(invalid)
+
+	return invalid
+}
+
+// AllowedDataFields sets the fields under `data` that Rego in ConstraintTemplates
+// can access. If unset, all fields can be accessed. Only fields recognized by
+// the system can be enabled.
+func AllowedDataFields(fields ...string) Opt {
+	return func(c *Client) error {
+		c.allowedDataFields = fields
+		return nil
+	}
+}

--- a/constraint/pkg/client/client_opts.go
+++ b/constraint/pkg/client/client_opts.go
@@ -20,7 +20,7 @@ func Targets(ts ...TargetHandler) Opt {
 		invalid := validateTargetNames(ts)
 		if len(invalid) > 0 {
 			return fmt.Errorf("%w: target names %v are not of the form %q",
-				errCreatingClient, invalid, targetNameRegex.String())
+				ErrCreatingClient, invalid, targetNameRegex.String())
 		}
 
 		for _, t := range ts {

--- a/constraint/pkg/client/client_test.go
+++ b/constraint/pkg/client/client_test.go
@@ -20,23 +20,6 @@ import (
 
 const badRego = `asd{`
 
-func TestClientE2E(t *testing.T) {
-	d := local.New()
-
-	p, err := NewProbe(d)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	for name, f := range p.TestFuncs() {
-		t.Run(name, func(t *testing.T) {
-			if err := f(); err != nil {
-				t.Fatal(err)
-			}
-		})
-	}
-}
-
 var _ TargetHandler = &badHandler{}
 
 type badHandler struct {

--- a/constraint/pkg/client/client_test.go
+++ b/constraint/pkg/client/client_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/open-policy-agent/frameworks/constraint/pkg/types"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/pointer"
 )
 
 const badRego = `asd{`
@@ -43,8 +44,7 @@ matching_reviews_and_constraints[[r,c]] {r = data.r; c = data.c}`))
 }
 
 func (h *badHandler) MatchSchema() apiextensions.JSONSchemaProps {
-	trueBool := true
-	return apiextensions.JSONSchemaProps{XPreserveUnknownFields: &trueBool}
+	return apiextensions.JSONSchemaProps{XPreserveUnknownFields: pointer.Bool(true)}
 }
 
 func (h *badHandler) ProcessData(obj interface{}) (bool, string, interface{}, error) {

--- a/constraint/pkg/client/client_test.go
+++ b/constraint/pkg/client/client_test.go
@@ -179,8 +179,8 @@ func TestAddData(t *testing.T) {
 			for _, v := range tt.ErroredBy {
 				expectedErr[v] = true
 			}
-			if e, ok := err.(ErrorMap); ok {
-				for k := range e {
+			if e, ok := err.(*ErrorMap); ok {
+				for k := range *e {
 					actualErr[k] = true
 				}
 			}
@@ -263,8 +263,8 @@ func TestRemoveData(t *testing.T) {
 			for _, v := range tt.ErroredBy {
 				expectedErr[v] = true
 			}
-			if e, ok := err.(ErrorMap); ok {
-				for k := range e {
+			if e, ok := err.(*ErrorMap); ok {
+				for k := range *e {
 					actualErr[k] = true
 				}
 			}

--- a/constraint/pkg/client/client_test.go
+++ b/constraint/pkg/client/client_test.go
@@ -3,21 +3,39 @@ package client
 import (
 	"context"
 	"errors"
-	"reflect"
 	"strings"
 	"testing"
 	"text/template"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/client/drivers/local"
-	constraintlib "github.com/open-policy-agent/frameworks/constraint/pkg/core/constraints"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/core/templates"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/types"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/pointer"
 )
 
 const badRego = `asd{`
+
+func TestClientE2E(t *testing.T) {
+	d := local.New()
+
+	p, err := NewProbe(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for name, f := range p.TestFuncs() {
+		t.Run(name, func(t *testing.T) {
+			if err := f(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
 
 var _ TargetHandler = &badHandler{}
 
@@ -47,7 +65,7 @@ func (h *badHandler) MatchSchema() apiextensions.JSONSchemaProps {
 	return apiextensions.JSONSchemaProps{XPreserveUnknownFields: pointer.Bool(true)}
 }
 
-func (h *badHandler) ProcessData(obj interface{}) (bool, string, interface{}, error) {
+func (h *badHandler) ProcessData(_ interface{}) (bool, string, interface{}, error) {
 	if h.Errors {
 		return false, "", nil, errors.New("some error")
 	}
@@ -57,239 +75,241 @@ func (h *badHandler) ProcessData(obj interface{}) (bool, string, interface{}, er
 	return true, "projects/something", nil, nil
 }
 
-func (h *badHandler) HandleReview(obj interface{}) (bool, interface{}, error) {
+func (h *badHandler) HandleReview(_ interface{}) (bool, interface{}, error) {
 	return false, "", nil
 }
 
-func (h *badHandler) HandleViolation(result *types.Result) error {
+func (h *badHandler) HandleViolation(_ *types.Result) error {
 	return nil
 }
 
-func (h *badHandler) ValidateConstraint(u *unstructured.Unstructured) error {
+func (h *badHandler) ValidateConstraint(_ *unstructured.Unstructured) error {
 	return nil
 }
 
 func TestInvalidTargetName(t *testing.T) {
-	tc := []struct {
-		Name          string
-		Handler       TargetHandler
-		ErrorExpected bool
+	tcs := []struct {
+		name      string
+		handler   TargetHandler
+		wantError error
 	}{
 		{
-			Name:          "Acceptable Name",
-			Handler:       &badHandler{Name: "Hello8", HasLib: true},
-			ErrorExpected: false,
+			name:      "Acceptable name",
+			handler:   &badHandler{Name: "Hello8", HasLib: true},
+			wantError: nil,
 		},
 		{
-			Name:          "No Name",
-			Handler:       &badHandler{Name: ""},
-			ErrorExpected: true,
+			name:      "No name",
+			handler:   &badHandler{Name: ""},
+			wantError: ErrCreatingClient,
 		},
 		{
-			Name:          "No Dots",
-			Handler:       &badHandler{Name: "asdf.asdf"},
-			ErrorExpected: true,
+			name:      "Dots not allowed",
+			handler:   &badHandler{Name: "asdf.asdf"},
+			wantError: ErrCreatingClient,
 		},
 		{
-			Name:          "No Spaces",
-			Handler:       &badHandler{Name: "asdf asdf"},
-			ErrorExpected: true,
+			name:      "Spaces not allowed",
+			handler:   &badHandler{Name: "asdf asdf"},
+			wantError: ErrCreatingClient,
 		},
 		{
-			Name:          "Must start with a letter",
-			Handler:       &badHandler{Name: "8asdf"},
-			ErrorExpected: true,
+			name:      "Must start with a letter",
+			handler:   &badHandler{Name: "8asdf"},
+			wantError: ErrCreatingClient,
 		},
 	}
-	for _, tt := range tc {
-		t.Run(tt.Name, func(t *testing.T) {
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
 			d := local.New()
+
 			b, err := NewBackend(Driver(d))
 			if err != nil {
 				t.Fatalf("Could not create backend: %s", err)
 			}
-			_, err = b.NewClient(Targets(tt.Handler))
-			if (err == nil) && tt.ErrorExpected {
-				t.Fatalf("err = nil; want non-nil")
-			}
-			if (err != nil) && !tt.ErrorExpected {
-				t.Fatalf("err = \"%s\"; want nil", err)
+
+			_, err = b.NewClient(Targets(tc.handler))
+			if !errors.Is(err, tc.wantError) {
+				t.Errorf("got NewClient() error = %v, want %v",
+					err, tc.wantError)
 			}
 		})
 	}
 }
 
 func TestAddData(t *testing.T) {
-	tc := []struct {
-		Name      string
-		Handler1  TargetHandler
-		Handler2  TargetHandler
-		ErroredBy []string
-		HandledBy []string
+	tcs := []struct {
+		name        string
+		handler1    TargetHandler
+		handler2    TargetHandler
+		wantHandled map[string]bool
+		wantError   map[string]bool
 	}{
 		{
-			Name:      "Handled By Both",
-			Handler1:  &badHandler{Name: "h1", HasLib: true, HandlesData: true},
-			Handler2:  &badHandler{Name: "h2", HasLib: true, HandlesData: true},
-			HandledBy: []string{"h1", "h2"},
+			name:        "Handled By Both",
+			handler1:    &badHandler{Name: "h1", HasLib: true, HandlesData: true},
+			handler2:    &badHandler{Name: "h2", HasLib: true, HandlesData: true},
+			wantHandled: map[string]bool{"h1": true, "h2": true},
+			wantError:   nil,
 		},
 		{
-			Name:      "Handled By One",
-			Handler1:  &badHandler{Name: "h1", HasLib: true, HandlesData: true},
-			Handler2:  &badHandler{Name: "h2", HasLib: true, HandlesData: false},
-			HandledBy: []string{"h1"},
+			name:        "Handled By One",
+			handler1:    &badHandler{Name: "h1", HasLib: true, HandlesData: true},
+			handler2:    &badHandler{Name: "h2", HasLib: true, HandlesData: false},
+			wantHandled: map[string]bool{"h1": true},
+			wantError:   nil,
 		},
 		{
-			Name:      "Errored By One",
-			Handler1:  &badHandler{Name: "h1", HasLib: true, HandlesData: true},
-			Handler2:  &badHandler{Name: "h2", HasLib: true, HandlesData: true, Errors: true},
-			HandledBy: []string{"h1"},
-			ErroredBy: []string{"h2"},
+			name:        "Errored By One",
+			handler1:    &badHandler{Name: "h1", HasLib: true, HandlesData: true},
+			handler2:    &badHandler{Name: "h2", HasLib: true, HandlesData: true, Errors: true},
+			wantHandled: map[string]bool{"h1": true},
+			wantError:   map[string]bool{"h2": true},
 		},
 		{
-			Name:      "Errored By Both",
-			Handler1:  &badHandler{Name: "h1", HasLib: true, HandlesData: true, Errors: true},
-			Handler2:  &badHandler{Name: "h2", HasLib: true, HandlesData: true, Errors: true},
-			ErroredBy: []string{"h1", "h2"},
+			name:      "Errored By Both",
+			handler1:  &badHandler{Name: "h1", HasLib: true, HandlesData: true, Errors: true},
+			handler2:  &badHandler{Name: "h2", HasLib: true, HandlesData: true, Errors: true},
+			wantError: map[string]bool{"h1": true, "h2": true},
 		},
 		{
-			Name:     "Handled By None",
-			Handler1: &badHandler{Name: "h1", HasLib: true, HandlesData: false},
-			Handler2: &badHandler{Name: "h2", HasLib: true, HandlesData: false},
+			name:        "Handled By None",
+			handler1:    &badHandler{Name: "h1", HasLib: true, HandlesData: false},
+			handler2:    &badHandler{Name: "h2", HasLib: true, HandlesData: false},
+			wantHandled: nil,
+			wantError:   nil,
 		},
 	}
-	for _, tt := range tc {
-		t.Run(tt.Name, func(t *testing.T) {
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
 			d := local.New()
+
 			b, err := NewBackend(Driver(d))
 			if err != nil {
 				t.Fatalf("Could not create backend: %s", err)
 			}
-			c, err := b.NewClient(Targets(tt.Handler1, tt.Handler2))
+
+			c, err := b.NewClient(Targets(tc.handler1, tc.handler2))
 			if err != nil {
 				t.Fatal(err)
 			}
+
 			r, err := c.AddData(context.Background(), nil)
-			if err != nil && len(tt.ErroredBy) == 0 {
+			if err != nil && len(tc.wantError) == 0 {
 				t.Fatalf("err = %s; want nil", err)
 			}
 
-			expectedErr := make(map[string]bool)
-			actualErr := make(map[string]bool)
-			for _, v := range tt.ErroredBy {
-				expectedErr[v] = true
-			}
+			gotErrs := make(map[string]bool)
 			if e, ok := err.(*ErrorMap); ok {
 				for k := range *e {
-					actualErr[k] = true
+					gotErrs[k] = true
 				}
 			}
-			if !reflect.DeepEqual(actualErr, expectedErr) {
-				t.Errorf("errSet = %v; wanted %v", actualErr, expectedErr)
+
+			if diff := cmp.Diff(tc.wantError, gotErrs, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf(diff)
 			}
-			expectedHandled := make(map[string]bool)
-			for _, v := range tt.HandledBy {
-				expectedHandled[v] = true
-			}
+
 			if r == nil {
 				t.Fatal("got AddTemplate() == nil, want non-nil")
 			}
-			if !reflect.DeepEqual(r.Handled, expectedHandled) {
-				t.Errorf("handledSet = %v; wanted %v", r.Handled, expectedHandled)
-			}
-			if r.HandledCount() != len(expectedHandled) {
-				t.Errorf("HandledCount() = %v; want %v", r.HandledCount(), len(expectedHandled))
+
+			if diff := cmp.Diff(tc.wantHandled, r.Handled, cmpopts.EquateEmpty()); diff != "" {
+				t.Error(diff)
 			}
 		})
 	}
 }
 
 func TestRemoveData(t *testing.T) {
-	tc := []struct {
-		Name      string
-		Handler1  TargetHandler
-		Handler2  TargetHandler
-		ErroredBy []string
-		HandledBy []string
+	tcs := []struct {
+		name        string
+		handler1    TargetHandler
+		handler2    TargetHandler
+		wantHandled map[string]bool
+		wantError   map[string]bool
 	}{
 		{
-			Name:      "Handled By Both",
-			Handler1:  &badHandler{Name: "h1", HasLib: true, HandlesData: true},
-			Handler2:  &badHandler{Name: "h2", HasLib: true, HandlesData: true},
-			HandledBy: []string{"h1", "h2"},
+			name:        "Handled By Both",
+			handler1:    &badHandler{Name: "h1", HasLib: true, HandlesData: true},
+			handler2:    &badHandler{Name: "h2", HasLib: true, HandlesData: true},
+			wantHandled: map[string]bool{"h1": true, "h2": true},
+			wantError:   nil,
 		},
 		{
-			Name:      "Handled By One",
-			Handler1:  &badHandler{Name: "h1", HasLib: true, HandlesData: true},
-			Handler2:  &badHandler{Name: "h2", HasLib: true, HandlesData: false},
-			HandledBy: []string{"h1"},
+			name:        "Handled By One",
+			handler1:    &badHandler{Name: "h1", HasLib: true, HandlesData: true},
+			handler2:    &badHandler{Name: "h2", HasLib: true, HandlesData: false},
+			wantHandled: map[string]bool{"h1": true},
+			wantError:   nil,
 		},
 		{
-			Name:      "Errored By One",
-			Handler1:  &badHandler{Name: "h1", HasLib: true, HandlesData: true},
-			Handler2:  &badHandler{Name: "h2", HasLib: true, HandlesData: true, Errors: true},
-			HandledBy: []string{"h1"},
-			ErroredBy: []string{"h2"},
+			name:        "Errored By One",
+			handler1:    &badHandler{Name: "h1", HasLib: true, HandlesData: true},
+			handler2:    &badHandler{Name: "h2", HasLib: true, HandlesData: true, Errors: true},
+			wantHandled: map[string]bool{"h1": true},
+			wantError:   map[string]bool{"h2": true},
 		},
 		{
-			Name:      "Errored By Both",
-			Handler1:  &badHandler{Name: "h1", HasLib: true, HandlesData: true, Errors: true},
-			Handler2:  &badHandler{Name: "h2", HasLib: true, HandlesData: true, Errors: true},
-			ErroredBy: []string{"h1", "h2"},
+			name:        "Errored By Both",
+			handler1:    &badHandler{Name: "h1", HasLib: true, HandlesData: true, Errors: true},
+			handler2:    &badHandler{Name: "h2", HasLib: true, HandlesData: true, Errors: true},
+			wantHandled: nil,
+			wantError:   map[string]bool{"h1": true, "h2": true},
 		},
 		{
-			Name:     "Handled By None",
-			Handler1: &badHandler{Name: "h1", HasLib: true, HandlesData: false},
-			Handler2: &badHandler{Name: "h2", HasLib: true, HandlesData: false},
+			name:        "Handled By None",
+			handler1:    &badHandler{Name: "h1", HasLib: true, HandlesData: false},
+			handler2:    &badHandler{Name: "h2", HasLib: true, HandlesData: false},
+			wantHandled: nil,
+			wantError:   nil,
 		},
 	}
-	for _, tt := range tc {
-		t.Run(tt.Name, func(t *testing.T) {
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
 			d := local.New()
+
 			b, err := NewBackend(Driver(d))
 			if err != nil {
 				t.Fatalf("Could not create backend: %s", err)
 			}
-			c, err := b.NewClient(Targets(tt.Handler1, tt.Handler2))
+
+			c, err := b.NewClient(Targets(tc.handler1, tc.handler2))
 			if err != nil {
 				t.Fatal(err)
 			}
+
 			r, err := c.RemoveData(context.Background(), nil)
-			if err != nil && len(tt.ErroredBy) == 0 {
+			if err != nil && len(tc.wantError) == 0 {
 				t.Fatalf("err = %s; want nil", err)
 			}
-			expectedErr := make(map[string]bool)
-			actualErr := make(map[string]bool)
-			for _, v := range tt.ErroredBy {
-				expectedErr[v] = true
-			}
+
+			gotErrs := make(map[string]bool)
 			if e, ok := err.(*ErrorMap); ok {
 				for k := range *e {
-					actualErr[k] = true
+					gotErrs[k] = true
 				}
 			}
-			if !reflect.DeepEqual(actualErr, expectedErr) {
-				t.Errorf("errSet = %v; wanted %v", actualErr, expectedErr)
-			}
-			expectedHandled := make(map[string]bool)
-			for _, v := range tt.HandledBy {
-				expectedHandled[v] = true
+
+			if diff := cmp.Diff(tc.wantError, gotErrs, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf(diff)
 			}
 
 			if r == nil {
 				t.Fatal("got RemoveData() == nil, want non-nil")
 			}
-			if !reflect.DeepEqual(r.Handled, expectedHandled) {
-				t.Errorf("handledSet = %v; wanted %v", r.Handled, expectedHandled)
-			}
-			if r.HandledCount() != len(expectedHandled) {
-				t.Errorf("HandledCount() = %v; want %v", r.HandledCount(), len(expectedHandled))
+
+			if diff := cmp.Diff(tc.wantHandled, r.Handled, cmpopts.EquateEmpty()); diff != "" {
+				t.Error(diff)
 			}
 		})
 	}
 }
 
-func TestAddTemplate(t *testing.T) {
+func TestClient_AddTemplate(t *testing.T) {
 	badRegoTempl := createTemplate(name("fake"), crdNames("Fake"), targets("h1"))
 	badRegoTempl.Spec.Targets[0].Rego = badRego
 
@@ -304,97 +324,97 @@ some_rule[r] {
 	emptyRegoTempl := createTemplate(name("fake"), crdNames("Fake"), targets("h1"))
 	emptyRegoTempl.Spec.Targets[0].Rego = ""
 
-	tc := []struct {
-		Name          string
-		Handler       TargetHandler
-		Template      *templates.ConstraintTemplate
-		ErrorExpected bool
+	tcs := []struct {
+		name        string
+		handler     TargetHandler
+		template    *templates.ConstraintTemplate
+		wantHandled map[string]bool
+		wantError   error
 	}{
 		{
-			Name:          "Good Template",
-			Handler:       &badHandler{Name: "h1", HasLib: true},
-			Template:      createTemplate(name("fakes"), crdNames("Fakes"), targets("h1")),
-			ErrorExpected: false,
+			name:        "Good Template",
+			handler:     &badHandler{Name: "h1", HasLib: true},
+			template:    createTemplate(name("fakes"), crdNames("Fakes"), targets("h1")),
+			wantHandled: map[string]bool{"h1": true},
+			wantError:   nil,
 		},
 		{
-			Name:          "Unknown Target",
-			Handler:       &badHandler{Name: "h1", HasLib: true},
-			Template:      createTemplate(name("fake"), crdNames("Fake"), targets("h2")),
-			ErrorExpected: true,
+			name:        "Unknown Target",
+			handler:     &badHandler{Name: "h1", HasLib: true},
+			template:    createTemplate(name("fake"), crdNames("Fake"), targets("h2")),
+			wantHandled: nil,
+			wantError:   ErrInvalidConstraintTemplate,
 		},
 		{
-			Name:          "Bad CRD",
-			Handler:       &badHandler{Name: "h1", HasLib: true},
-			Template:      createTemplate(name("fakes"), targets("h1")),
-			ErrorExpected: true,
+			name:        "Bad CRD",
+			handler:     &badHandler{Name: "h1", HasLib: true},
+			template:    createTemplate(name("fakes"), targets("h1")),
+			wantHandled: nil,
+			wantError:   ErrInvalidConstraintTemplate,
 		},
 		{
-			Name:          "No Name",
-			Handler:       &badHandler{Name: "h1", HasLib: true},
-			Template:      createTemplate(crdNames("Fake"), targets("h1")),
-			ErrorExpected: true,
+			name:        "No name",
+			handler:     &badHandler{Name: "h1", HasLib: true},
+			template:    createTemplate(crdNames("Fake"), targets("h1")),
+			wantHandled: nil,
+			wantError:   ErrInvalidConstraintTemplate,
 		},
 		{
-			Name:          "Bad Rego",
-			Handler:       &badHandler{Name: "h1", HasLib: true},
-			Template:      badRegoTempl,
-			ErrorExpected: true,
+			name:        "Bad Rego",
+			handler:     &badHandler{Name: "h1", HasLib: true},
+			template:    badRegoTempl,
+			wantHandled: nil,
+			wantError:   ErrInvalidConstraintTemplate,
 		},
 		{
-			Name:          "No Rego",
-			Handler:       &badHandler{Name: "h1", HasLib: true},
-			Template:      emptyRegoTempl,
-			ErrorExpected: true,
+			name:        "No Rego",
+			handler:     &badHandler{Name: "h1", HasLib: true},
+			template:    emptyRegoTempl,
+			wantHandled: nil,
+			wantError:   ErrInvalidConstraintTemplate,
 		},
 		{
-			Name:          "Missing Rule",
-			Handler:       &badHandler{Name: "h1", HasLib: true},
-			Template:      missingRuleTempl,
-			ErrorExpected: true,
+			name:        "Missing Rule",
+			handler:     &badHandler{Name: "h1", HasLib: true},
+			template:    missingRuleTempl,
+			wantHandled: nil,
+			wantError:   ErrInvalidConstraintTemplate,
 		},
 	}
-	for _, tt := range tc {
-		t.Run(tt.Name, func(t *testing.T) {
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
 			d := local.New()
+
 			b, err := NewBackend(Driver(d))
 			if err != nil {
 				t.Fatalf("Could not create backend: %s", err)
 			}
-			c, err := b.NewClient(Targets(tt.Handler))
+
+			c, err := b.NewClient(Targets(tc.handler))
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			r, err := c.AddTemplate(context.Background(), tt.Template)
-			if err != nil && !tt.ErrorExpected {
-				t.Fatalf("err = %v; want nil", err)
-			}
-			if err == nil && tt.ErrorExpected {
-				t.Error("err = nil; want non-nil")
+			r, err := c.AddTemplate(context.Background(), tc.template)
+			if !errors.Is(err, tc.wantError) {
+				t.Fatalf("got AddTemplate() error = %v, want %v",
+					err, tc.wantError)
 			}
 
-			expectedCount := 0
-			expectedHandled := make(map[string]bool)
-			if !tt.ErrorExpected {
-				expectedCount = 1
-				expectedHandled = map[string]bool{"h1": true}
-			}
 			if r == nil {
 				t.Fatal("got AddTemplate() == nil, want non-nil")
 			}
-			if r.HandledCount() != expectedCount {
-				t.Errorf("HandledCount() = %v; want %v", r.HandledCount(), expectedCount)
-			}
-			if !reflect.DeepEqual(r.Handled, expectedHandled) {
-				t.Errorf("r.Handled = %v; want %v", r.Handled, expectedHandled)
+
+			if diff := cmp.Diff(r.Handled, tc.wantHandled, cmpopts.EquateEmpty()); diff != "" {
+				t.Error(diff)
 			}
 
-			cached, err := c.GetTemplate(context.Background(), tt.Template)
-			if err == nil && tt.ErrorExpected {
-				t.Fatal("retrieved template when error was expected")
-			}
-
-			if tt.ErrorExpected {
+			cached, err := c.GetTemplate(context.Background(), tc.template)
+			if tc.wantError != nil {
+				if err == nil {
+					t.Fatalf("got GetTemplate() error = %v, want non-nil", err)
+				}
 				return
 			}
 
@@ -402,17 +422,20 @@ some_rule[r] {
 				t.Fatalf("could not retrieve template when error was expected: %v", err)
 			}
 
-			if !cached.SemanticEqual(tt.Template) {
+			if !cached.SemanticEqual(tc.template) {
 				t.Error("cached template does not equal stored template")
 			}
-			r2, err := c.RemoveTemplate(context.Background(), tt.Template)
+
+			r2, err := c.RemoveTemplate(context.Background(), tc.template)
 			if err != nil {
 				t.Fatal("could not remove template")
 			}
+
 			if r2.HandledCount() != 1 {
 				t.Error("more targets handled than expected")
 			}
-			if _, err := c.GetTemplate(context.Background(), tt.Template); err == nil {
+
+			if _, err := c.GetTemplate(context.Background(), tc.template); err == nil {
 				t.Error("template not cleared from cache")
 			}
 		})
@@ -422,64 +445,62 @@ some_rule[r] {
 func TestRemoveTemplate(t *testing.T) {
 	badRegoTempl := createTemplate(name("fake"), crdNames("Fake"), targets("h1"))
 	badRegoTempl.Spec.Targets[0].Rego = badRego
-	tc := []struct {
-		Name          string
-		Handler       TargetHandler
-		Template      *templates.ConstraintTemplate
-		ErrorExpected bool
+	tcs := []struct {
+		name        string
+		handler     TargetHandler
+		template    *templates.ConstraintTemplate
+		wantHandled map[string]bool
+		wantError   error
 	}{
 		{
-			Name:          "Good Template",
-			Handler:       &badHandler{Name: "h1", HasLib: true},
-			Template:      createTemplate(name("fake"), crdNames("Fake"), targets("h1")),
-			ErrorExpected: false,
+			name:        "Good Template",
+			handler:     &badHandler{Name: "h1", HasLib: true},
+			template:    createTemplate(name("fake"), crdNames("Fake"), targets("h1")),
+			wantHandled: map[string]bool{"h1": true},
+			wantError:   nil,
 		},
 		{
-			Name:          "Unknown Target",
-			Handler:       &badHandler{Name: "h1", HasLib: true},
-			Template:      createTemplate(name("fake"), crdNames("Fake"), targets("h2")),
-			ErrorExpected: true,
+			name:        "Unknown Target",
+			handler:     &badHandler{Name: "h1", HasLib: true},
+			template:    createTemplate(name("fake"), crdNames("Fake"), targets("h2")),
+			wantHandled: nil,
+			wantError:   ErrInvalidConstraintTemplate,
 		},
 		{
-			Name:          "Bad CRD",
-			Handler:       &badHandler{Name: "h1", HasLib: true},
-			Template:      createTemplate(name("fake"), targets("h1")),
-			ErrorExpected: true,
+			name:        "Bad CRD",
+			handler:     &badHandler{Name: "h1", HasLib: true},
+			template:    createTemplate(name("fake"), targets("h1")),
+			wantHandled: nil,
+			wantError:   ErrInvalidConstraintTemplate,
 		},
 	}
-	for _, tt := range tc {
-		t.Run(tt.Name, func(t *testing.T) {
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
 			d := local.New()
+
 			b, err := NewBackend(Driver(d))
 			if err != nil {
 				t.Fatalf("Could not create backend: %s", err)
 			}
-			c, err := b.NewClient(Targets(tt.Handler))
+
+			c, err := b.NewClient(Targets(tc.handler))
 			if err != nil {
 				t.Fatal(err)
 			}
-			_, err = c.AddTemplate(context.Background(), tt.Template)
-			if err != nil && !tt.ErrorExpected {
-				t.Errorf("err = %v; want nil", err)
+
+			_, err = c.AddTemplate(context.Background(), tc.template)
+			if !errors.Is(err, tc.wantError) {
+				t.Fatalf("got AddTemplate() error = %v, want %v",
+					err, tc.wantError)
 			}
-			if err == nil && tt.ErrorExpected {
-				t.Error("err = nil; want non-nil")
-			}
-			r, err := c.RemoveTemplate(context.Background(), tt.Template)
+
+			r, err := c.RemoveTemplate(context.Background(), tc.template)
 			if err != nil {
 				t.Errorf("err = %v; want nil", err)
 			}
-			expectedCount := 0
-			expectedHandled := make(map[string]bool)
-			if !tt.ErrorExpected {
-				expectedCount = 1
-				expectedHandled = map[string]bool{"h1": true}
-			}
-			if r.HandledCount() != expectedCount {
-				t.Errorf("HandledCount() = %v; want %v", r.HandledCount(), expectedCount)
-			}
-			if !reflect.DeepEqual(r.Handled, expectedHandled) {
-				t.Errorf("r.Handled = %v; want %v", r.Handled, expectedHandled)
+
+			if diff := cmp.Diff(tc.wantHandled, r.Handled, cmpopts.EquateEmpty()); diff != "" {
+				t.Error(diff)
 			}
 		})
 	}
@@ -488,66 +509,66 @@ func TestRemoveTemplate(t *testing.T) {
 func TestRemoveTemplateByNameOnly(t *testing.T) {
 	badRegoTempl := createTemplate(name("fake"), crdNames("Fake"), targets("h1"))
 	badRegoTempl.Spec.Targets[0].Rego = badRego
-	tc := []struct {
-		Name          string
-		Handler       TargetHandler
-		Template      *templates.ConstraintTemplate
-		ErrorExpected bool
+	tcs := []struct {
+		name        string
+		handler     TargetHandler
+		template    *templates.ConstraintTemplate
+		wantHandled map[string]bool
+		wantError   error
 	}{
 		{
-			Name:          "Good Template",
-			Handler:       &badHandler{Name: "h1", HasLib: true},
-			Template:      createTemplate(name("fake"), crdNames("Fake"), targets("h1")),
-			ErrorExpected: false,
+			name:        "Good Template",
+			handler:     &badHandler{Name: "h1", HasLib: true},
+			template:    createTemplate(name("fake"), crdNames("Fake"), targets("h1")),
+			wantHandled: map[string]bool{"h1": true},
+			wantError:   nil,
 		},
 		{
-			Name:          "Unknown Target",
-			Handler:       &badHandler{Name: "h1", HasLib: true},
-			Template:      createTemplate(name("fake"), crdNames("Fake"), targets("h2")),
-			ErrorExpected: true,
+			name:        "Unknown Target",
+			handler:     &badHandler{Name: "h1", HasLib: true},
+			template:    createTemplate(name("fake"), crdNames("Fake"), targets("h2")),
+			wantHandled: nil,
+			wantError:   ErrInvalidConstraintTemplate,
 		},
 		{
-			Name:          "Bad CRD",
-			Handler:       &badHandler{Name: "h1", HasLib: true},
-			Template:      createTemplate(name("fake"), targets("h1")),
-			ErrorExpected: true,
+			name:        "Bad CRD",
+			handler:     &badHandler{Name: "h1", HasLib: true},
+			template:    createTemplate(name("fake"), targets("h1")),
+			wantHandled: nil,
+			wantError:   ErrInvalidConstraintTemplate,
 		},
 	}
-	for _, tt := range tc {
-		t.Run(tt.Name, func(t *testing.T) {
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
 			d := local.New()
+
 			b, err := NewBackend(Driver(d))
 			if err != nil {
 				t.Fatalf("Could not create backend: %s", err)
 			}
-			c, err := b.NewClient(Targets(tt.Handler))
+
+			c, err := b.NewClient(Targets(tc.handler))
 			if err != nil {
 				t.Fatal(err)
 			}
-			_, err = c.AddTemplate(context.Background(), tt.Template)
-			if err != nil && !tt.ErrorExpected {
-				t.Errorf("err = %v; want nil", err)
+
+			_, err = c.AddTemplate(context.Background(), tc.template)
+			if !errors.Is(err, tc.wantError) {
+				t.Fatalf("got AddTemplate() error = %v, want %v",
+					err, tc.wantError)
 			}
-			if err == nil && tt.ErrorExpected {
-				t.Error("err = nil; want non-nil")
-			}
+
 			sparseTemplate := &templates.ConstraintTemplate{}
-			sparseTemplate.Name = tt.Template.Name
+			sparseTemplate.Name = tc.template.Name
+
 			r, err := c.RemoveTemplate(context.Background(), sparseTemplate)
 			if err != nil {
 				t.Errorf("err = %v; want nil", err)
 			}
-			expectedCount := 0
-			expectedHandled := make(map[string]bool)
-			if !tt.ErrorExpected {
-				expectedCount = 1
-				expectedHandled = map[string]bool{"h1": true}
-			}
-			if r.HandledCount() != expectedCount {
-				t.Errorf("HandledCount() = %v; want %v", r.HandledCount(), expectedCount)
-			}
-			if !reflect.DeepEqual(r.Handled, expectedHandled) {
-				t.Errorf("r.Handled = %v; want %v", r.Handled, expectedHandled)
+
+			if diff := cmp.Diff(tc.wantHandled, r.Handled, cmpopts.EquateEmpty()); diff != "" {
+				t.Error(diff)
 			}
 		})
 	}
@@ -556,60 +577,69 @@ func TestRemoveTemplateByNameOnly(t *testing.T) {
 func TestGetTemplate(t *testing.T) {
 	badRegoTempl := createTemplate(name("fake"), crdNames("Fake"), targets("h1"))
 	badRegoTempl.Spec.Targets[0].Rego = badRego
-	tc := []struct {
-		Name          string
-		Handler       TargetHandler
-		Template      *templates.ConstraintTemplate
-		ErrorExpected bool
+
+	tcs := []struct {
+		name         string
+		handler      TargetHandler
+		wantTemplate *templates.ConstraintTemplate
+		wantAddError error
+		wantGetError error
 	}{
 		{
-			Name:          "Good Template",
-			Handler:       &badHandler{Name: "h1", HasLib: true},
-			Template:      createTemplate(name("fake"), crdNames("Fake"), targets("h1")),
-			ErrorExpected: false,
+			name:         "Good Template",
+			handler:      &badHandler{Name: "h1", HasLib: true},
+			wantTemplate: createTemplate(name("fake"), crdNames("Fake"), targets("h1")),
+			wantAddError: nil,
+			wantGetError: nil,
 		},
 		{
-			Name:          "Unknown Target",
-			Handler:       &badHandler{Name: "h1", HasLib: true},
-			Template:      createTemplate(name("fake"), crdNames("Fake"), targets("h2")),
-			ErrorExpected: true,
+			name:         "Unknown Target",
+			handler:      &badHandler{Name: "h1", HasLib: true},
+			wantTemplate: createTemplate(name("fake"), crdNames("Fake"), targets("h2")),
+			wantAddError: ErrInvalidConstraintTemplate,
+			wantGetError: ErrMissingConstraintTemplate,
 		},
 		{
-			Name:          "Bad CRD",
-			Handler:       &badHandler{Name: "h1", HasLib: true},
-			Template:      createTemplate(name("fake"), targets("h1")),
-			ErrorExpected: true,
+			name:         "Bad CRD",
+			handler:      &badHandler{Name: "h1", HasLib: true},
+			wantTemplate: createTemplate(name("fake"), targets("h1")),
+			wantAddError: ErrInvalidConstraintTemplate,
+			wantGetError: ErrMissingConstraintTemplate,
 		},
 	}
-	for _, tt := range tc {
-		t.Run(tt.Name, func(t *testing.T) {
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
 			d := local.New()
+
 			b, err := NewBackend(Driver(d))
 			if err != nil {
 				t.Fatalf("Could not create backend: %s", err)
 			}
-			c, err := b.NewClient(Targets(tt.Handler))
+
+			c, err := b.NewClient(Targets(tc.handler))
 			if err != nil {
 				t.Fatal(err)
 			}
-			_, err = c.AddTemplate(context.Background(), tt.Template)
-			if err != nil && !tt.ErrorExpected {
-				t.Errorf("err = %v; want nil", err)
+
+			_, err = c.AddTemplate(context.Background(), tc.wantTemplate)
+			if !errors.Is(err, tc.wantAddError) {
+				t.Fatalf("got AddTemplate() error = %v, want %v",
+					err, tc.wantAddError)
 			}
-			if err == nil && tt.ErrorExpected {
-				t.Error("err = nil; want non-nil")
+
+			gotTemplate, err := c.GetTemplate(context.Background(), tc.wantTemplate)
+			if !errors.Is(err, tc.wantGetError) {
+				t.Fatalf("got GetTemplate() error = %v, want %v",
+					err, tc.wantGetError)
 			}
-			tmpl, err := c.GetTemplate(context.Background(), tt.Template)
-			if err != nil && !tt.ErrorExpected {
-				t.Errorf("err = %v; want nil", err)
+
+			if tc.wantAddError != nil {
+				return
 			}
-			if err == nil && tt.ErrorExpected {
-				t.Error("err = nil; want non-nil")
-			}
-			if !tt.ErrorExpected {
-				if !reflect.DeepEqual(tmpl, tt.Template) {
-					t.Error("Stored and retrieved template differ")
-				}
+
+			if diff := cmp.Diff(tc.wantTemplate, gotTemplate); diff != "" {
+				t.Error(diff)
 			}
 		})
 	}
@@ -618,62 +648,72 @@ func TestGetTemplate(t *testing.T) {
 func TestGetTemplateByNameOnly(t *testing.T) {
 	badRegoTempl := createTemplate(name("fake"), crdNames("Fake"), targets("h1"))
 	badRegoTempl.Spec.Targets[0].Rego = badRego
-	tc := []struct {
-		Name          string
-		Handler       TargetHandler
-		Template      *templates.ConstraintTemplate
-		ErrorExpected bool
+
+	tcs := []struct {
+		name         string
+		handler      TargetHandler
+		wantTemplate *templates.ConstraintTemplate
+		wantAddError error
+		wantGetError error
 	}{
 		{
-			Name:          "Good Template",
-			Handler:       &badHandler{Name: "h1", HasLib: true},
-			Template:      createTemplate(name("fake"), crdNames("Fake"), targets("h1")),
-			ErrorExpected: false,
+			name:         "Good Template",
+			handler:      &badHandler{Name: "h1", HasLib: true},
+			wantTemplate: createTemplate(name("fake"), crdNames("Fake"), targets("h1")),
+			wantAddError: nil,
+			wantGetError: nil,
 		},
 		{
-			Name:          "Unknown Target",
-			Handler:       &badHandler{Name: "h1", HasLib: true},
-			Template:      createTemplate(name("fake"), crdNames("Fake"), targets("h2")),
-			ErrorExpected: true,
+			name:         "Unknown Target",
+			handler:      &badHandler{Name: "h1", HasLib: true},
+			wantTemplate: createTemplate(name("fake"), crdNames("Fake"), targets("h2")),
+			wantAddError: ErrInvalidConstraintTemplate,
+			wantGetError: ErrMissingConstraintTemplate,
 		},
 		{
-			Name:          "Bad CRD",
-			Handler:       &badHandler{Name: "h1", HasLib: true},
-			Template:      createTemplate(name("fake"), targets("h1")),
-			ErrorExpected: true,
+			name:         "Bad CRD",
+			handler:      &badHandler{Name: "h1", HasLib: true},
+			wantTemplate: createTemplate(name("fake"), targets("h1")),
+			wantAddError: ErrInvalidConstraintTemplate,
+			wantGetError: ErrMissingConstraintTemplate,
 		},
 	}
-	for _, tt := range tc {
-		t.Run(tt.Name, func(t *testing.T) {
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
 			d := local.New()
+
 			b, err := NewBackend(Driver(d))
 			if err != nil {
 				t.Fatalf("Could not create backend: %s", err)
 			}
-			c, err := b.NewClient(Targets(tt.Handler))
+
+			c, err := b.NewClient(Targets(tc.handler))
 			if err != nil {
 				t.Fatal(err)
 			}
-			_, err = c.AddTemplate(context.Background(), tt.Template)
-			if err != nil && !tt.ErrorExpected {
-				t.Errorf("err = %v; want nil", err)
+
+			_, err = c.AddTemplate(context.Background(), tc.wantTemplate)
+			if !errors.Is(err, tc.wantAddError) {
+				t.Fatalf("got AddTemplate() error = %v, want %v",
+					err, tc.wantAddError)
 			}
-			if err == nil && tt.ErrorExpected {
-				t.Error("err = nil; want non-nil")
-			}
+
 			sparseTemplate := &templates.ConstraintTemplate{}
-			sparseTemplate.Name = tt.Template.Name
-			tmpl, err := c.GetTemplate(context.Background(), sparseTemplate)
-			if err != nil && !tt.ErrorExpected {
-				t.Errorf("err = %v; want nil", err)
+			sparseTemplate.Name = tc.wantTemplate.Name
+
+			gotTemplate, err := c.GetTemplate(context.Background(), sparseTemplate)
+			if !errors.Is(err, tc.wantGetError) {
+				t.Fatalf("Got GetTemplate() error = %v, want %v",
+					err, tc.wantGetError)
 			}
-			if err == nil && tt.ErrorExpected {
-				t.Error("err = nil; want non-nil")
+
+			if tc.wantGetError != nil {
+				return
 			}
-			if !tt.ErrorExpected {
-				if !reflect.DeepEqual(tmpl, tt.Template) {
-					t.Error("Stored and retrieved template differ")
-				}
+
+			if diff := cmp.Diff(tc.wantTemplate, gotTemplate); diff != "" {
+				t.Error(diff)
 			}
 		})
 	}
@@ -687,10 +727,12 @@ func TestTemplateCascadingDelete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Could not create backend: %s", err)
 	}
+
 	c, err := b.NewClient(Targets(handler))
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	templ := createTemplate(name("cascadingdelete"), crdNames("CascadingDelete"), targets("h1"))
 	if _, err = c.AddTemplate(context.Background(), templ); err != nil {
 		t.Errorf("err = %v; want nil", err)
@@ -700,6 +742,7 @@ func TestTemplateCascadingDelete(t *testing.T) {
 	if _, err = c.AddConstraint(context.Background(), cst1); err != nil {
 		t.Error("could not add first constraint")
 	}
+
 	cst2 := newConstraint("CascadingDelete", "cascadingdelete2", nil, nil)
 	if _, err = c.AddConstraint(context.Background(), cst2); err != nil {
 		t.Error("could not add second constraint")
@@ -714,6 +757,7 @@ func TestTemplateCascadingDelete(t *testing.T) {
 	if _, err = c.AddConstraint(context.Background(), cst3); err != nil {
 		t.Error("could not add third constraint")
 	}
+
 	cst4 := newConstraint("StillPersists", "stillpersists2", nil, nil)
 	if _, err = c.AddConstraint(context.Background(), cst4); err != nil {
 		t.Error("could not add fourth constraint")
@@ -738,6 +782,7 @@ func TestTemplateCascadingDelete(t *testing.T) {
 	if _, err = c.RemoveTemplate(context.Background(), templ); err != nil {
 		t.Error("could not remove template")
 	}
+
 	if len(c.constraints) != 1 {
 		t.Errorf("constraint cache expected to have only 1 entry: %+v", c.constraints)
 	}
@@ -746,10 +791,12 @@ func TestTemplateCascadingDelete(t *testing.T) {
 	if err != nil {
 		t.Errorf("could not dump OPA cache")
 	}
+
 	sLower := strings.ToLower(s)
 	if strings.Contains(sLower, "cascadingdelete") {
 		t.Errorf("Template not removed from cache: %s", s)
 	}
+
 	finalPreserved := strings.Count(sLower, "stillpersists")
 	if finalPreserved != origPreserved {
 		t.Errorf("finalPreserved = %d, expected %d :: %s", finalPreserved, origPreserved, s)
@@ -757,148 +804,169 @@ func TestTemplateCascadingDelete(t *testing.T) {
 }
 
 func TestAddConstraint(t *testing.T) {
-	tc := []struct {
-		Name          string
-		Constraint    *unstructured.Unstructured
-		OmitTemplate  bool
-		ErrorExpected bool
+	handler := &badHandler{Name: "h1", HasLib: true}
+
+	tcs := []struct {
+		name                   string
+		template               *templates.ConstraintTemplate
+		constraint             *unstructured.Unstructured
+		wantHandled            map[string]bool
+		wantAddConstraintError error
+		wantGetConstraintError error
 	}{
 		{
-			Name:       "Good Constraint",
-			Constraint: newConstraint("Foos", "foo", nil, nil),
+			name:                   "Good Constraint",
+			template:               createTemplate(name("foos"), crdNames("Foos"), targets("h1")),
+			constraint:             newConstraint("Foos", "foo", nil, nil),
+			wantHandled:            map[string]bool{"h1": true},
+			wantAddConstraintError: nil,
+			wantGetConstraintError: nil,
 		},
 		{
-			Name:          "No Name",
-			Constraint:    newConstraint("Foos", "", nil, nil),
-			ErrorExpected: true,
+			name:                   "No Name",
+			template:               createTemplate(name("foos"), crdNames("Foos"), targets("h1")),
+			constraint:             newConstraint("Foos", "", nil, nil),
+			wantHandled:            nil,
+			wantAddConstraintError: ErrInvalidConstraint,
+			wantGetConstraintError: ErrInvalidConstraint,
 		},
 		{
-			Name:          "No Kind",
-			Constraint:    newConstraint("", "foo", nil, nil),
-			ErrorExpected: true,
+			name:                   "No Kind",
+			template:               createTemplate(name("foos"), crdNames("Foos"), targets("h1")),
+			constraint:             newConstraint("", "foo", nil, nil),
+			wantHandled:            nil,
+			wantAddConstraintError: ErrInvalidConstraint,
+			wantGetConstraintError: ErrInvalidConstraint,
 		},
 		{
-			Name:          "No Template",
-			Constraint:    newConstraint("Foo", "foo", nil, nil),
-			OmitTemplate:  true,
-			ErrorExpected: true,
+			name:                   "No Template",
+			template:               nil,
+			constraint:             newConstraint("Foo", "foo", nil, nil),
+			wantHandled:            nil,
+			wantAddConstraintError: ErrMissingConstraintTemplate,
+			wantGetConstraintError: ErrMissingConstraint,
 		},
 	}
-	for _, tt := range tc {
-		t.Run(tt.Name, func(t *testing.T) {
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
 			d := local.New()
+
 			b, err := NewBackend(Driver(d))
 			if err != nil {
-				t.Fatalf("Could not create backend: %s", err)
+				t.Fatal(err)
 			}
-			handler := &badHandler{Name: "h1", HasLib: true}
+
 			c, err := b.NewClient(Targets(handler))
 			if err != nil {
 				t.Fatal(err)
 			}
-			if !tt.OmitTemplate {
-				tmpl := createTemplate(name("foos"), crdNames("Foos"), targets("h1"))
-				_, err := c.AddTemplate(context.Background(), tmpl)
+
+			if tc.template != nil {
+				_, err = c.AddTemplate(context.Background(), tc.template)
 				if err != nil {
 					t.Fatal(err)
 				}
 			}
-			r, err := c.AddConstraint(context.Background(), tt.Constraint)
-			if err != nil && !tt.ErrorExpected {
-				t.Errorf("err = %v; want nil", err)
-			}
-			if err == nil && tt.ErrorExpected {
-				t.Error("err = nil; want non-nil")
-			}
-			expectedCount := 0
-			expectedHandled := make(map[string]bool)
-			if !tt.ErrorExpected {
-				expectedCount = 1
-				expectedHandled = map[string]bool{"h1": true}
+
+			r, err := c.AddConstraint(context.Background(), tc.constraint)
+			if !errors.Is(err, tc.wantAddConstraintError) {
+				t.Fatalf("got AddConstraint() error = %v, want %v",
+					err, tc.wantAddConstraintError)
 			}
 
 			if r == nil {
 				t.Fatal("got AddConstraint() == nil, want non-nil")
 			}
-			if r.HandledCount() != expectedCount {
-				t.Errorf("HandledCount() = %v; want %v", r.HandledCount(), expectedCount)
-			}
-			if !reflect.DeepEqual(r.Handled, expectedHandled) {
-				t.Errorf("r.Handled = %v; want %v", r.Handled, expectedHandled)
-			}
-			cached, err := c.GetConstraint(context.Background(), tt.Constraint)
-			if err == nil && tt.ErrorExpected {
-				t.Error("retrieved constraint when error was expected")
-			}
-			if err != nil && !tt.ErrorExpected {
-				t.Error("could not retrieve constraint when error was expected")
-			}
-			if !tt.ErrorExpected {
-				if !constraintlib.SemanticEqual(cached, tt.Constraint) {
-					t.Error("cached constraint does not equal stored constraint")
-				}
-				r2, err := c.RemoveConstraint(context.Background(), tt.Constraint)
-				if err != nil {
-					t.Error("could not remove constraint")
-				}
 
-				if r2 == nil {
-					t.Fatal("got RemoveConstraint() == nil, want non-nil")
-				}
-				if r2.HandledCount() != 1 {
-					t.Error("more targets handled than expected")
-				}
-				if _, err := c.GetConstraint(context.Background(), tt.Constraint); err == nil {
-					t.Error("constraint not cleared from cache")
-				}
+			if diff := cmp.Diff(tc.wantHandled, r.Handled, cmpopts.EquateEmpty()); diff != "" {
+				t.Error(diff)
+			}
+
+			cached, err := c.GetConstraint(context.Background(), tc.constraint)
+			if !errors.Is(err, tc.wantGetConstraintError) {
+				t.Fatalf("got GetConstraint() error = %v, want %v",
+					err, tc.wantGetConstraintError)
+			}
+
+			if tc.wantGetConstraintError != nil {
+				return
+			}
+
+			if diff := cmp.Diff(tc.constraint.Object["spec"], cached.Object["spec"]); diff != "" {
+				t.Error("cached constraint does not equal stored constraint")
+			}
+
+			r2, err := c.RemoveConstraint(context.Background(), tc.constraint)
+			if err != nil {
+				t.Error("could not remove constraint")
+			}
+
+			if r2 == nil {
+				t.Fatal("got RemoveConstraint() == nil, want non-nil")
+			}
+
+			if r2.HandledCount() != 1 {
+				t.Error("more targets handled than expected")
+			}
+
+			if _, err := c.GetConstraint(context.Background(), tc.constraint); err == nil {
+				t.Error("constraint not cleared from cache")
 			}
 		})
 	}
 }
 
 func TestRemoveConstraint(t *testing.T) {
-	tc := []struct {
-		name       string
-		template   *templates.ConstraintTemplate
-		constraint *unstructured.Unstructured
-		toRemove   *unstructured.Unstructured
-		wantError  error
+	tcs := []struct {
+		name        string
+		template    *templates.ConstraintTemplate
+		constraint  *unstructured.Unstructured
+		toRemove    *unstructured.Unstructured
+		wantHandled map[string]bool
+		wantError   error
 	}{
 		{
-			name:       "Good Constraint",
-			template:   createTemplate(name("foos"), crdNames("Foos"), targets("h1")),
-			constraint: newConstraint("Foos", "foo", nil, nil),
-			toRemove:   newConstraint("Foos", "foo", nil, nil),
-			wantError:  nil,
+			name:        "Good Constraint",
+			template:    createTemplate(name("foos"), crdNames("Foos"), targets("h1")),
+			constraint:  newConstraint("Foos", "foo", nil, nil),
+			toRemove:    newConstraint("Foos", "foo", nil, nil),
+			wantHandled: map[string]bool{"h1": true},
+			wantError:   nil,
 		},
 		{
-			name:       "No Name",
-			template:   createTemplate(name("foos"), crdNames("Foos"), targets("h1")),
-			constraint: newConstraint("Foos", "foo", nil, nil),
-			toRemove:   newConstraint("Foos", "", nil, nil),
-			wantError:  errInvalidConstraint,
+			name:        "No name",
+			template:    createTemplate(name("foos"), crdNames("Foos"), targets("h1")),
+			constraint:  newConstraint("Foos", "foo", nil, nil),
+			toRemove:    newConstraint("Foos", "", nil, nil),
+			wantHandled: nil,
+			wantError:   ErrInvalidConstraint,
 		},
 		{
-			name:       "No Kind",
-			template:   createTemplate(name("foos"), crdNames("Foos"), targets("h1")),
-			constraint: newConstraint("Foos", "foo", nil, nil),
-			toRemove:   newConstraint("", "foo", nil, nil),
-			wantError:  errInvalidConstraint,
+			name:        "No Kind",
+			template:    createTemplate(name("foos"), crdNames("Foos"), targets("h1")),
+			constraint:  newConstraint("Foos", "foo", nil, nil),
+			toRemove:    newConstraint("", "foo", nil, nil),
+			wantHandled: nil,
+			wantError:   ErrInvalidConstraint,
 		},
 		{
-			name:      "No Template",
-			toRemove:  newConstraint("Foos", "foo", nil, nil),
-			wantError: errMissingConstraintTemplate,
+			name:        "No Template",
+			toRemove:    newConstraint("Foos", "foo", nil, nil),
+			wantHandled: nil,
+			wantError:   ErrMissingConstraintTemplate,
 		},
 		{
-			name:      "No Constraint",
-			template:  createTemplate(name("foos"), crdNames("Foos"), targets("h1")),
-			toRemove:  newConstraint("Foos", "bar", nil, nil),
-			wantError: nil,
+			name:        "No Constraint",
+			template:    createTemplate(name("foos"), crdNames("Foos"), targets("h1")),
+			toRemove:    newConstraint("Foos", "bar", nil, nil),
+			wantHandled: map[string]bool{"h1": true},
+			wantError:   nil,
 		},
 	}
-	for _, tt := range tc {
-		t.Run(tt.name, func(t *testing.T) {
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 
 			d := local.New()
@@ -906,50 +974,40 @@ func TestRemoveConstraint(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Could not create backend: %s", err)
 			}
+
 			handler := &badHandler{Name: "h1", HasLib: true}
 			c, err := b.NewClient(Targets(handler))
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			if tt.template != nil {
-				_, err = c.AddTemplate(ctx, tt.template)
+			if tc.template != nil {
+				_, err = c.AddTemplate(ctx, tc.template)
 				if err != nil {
 					t.Fatal(err)
 				}
 			}
 
-			if tt.constraint != nil {
-				_, err = c.AddConstraint(ctx, tt.constraint)
+			if tc.constraint != nil {
+				_, err = c.AddConstraint(ctx, tc.constraint)
 				if err != nil {
 					t.Fatal(err)
 				}
 			}
 
-			r, err := c.RemoveConstraint(context.Background(), tt.toRemove)
+			r, err := c.RemoveConstraint(context.Background(), tc.toRemove)
 
-			if !errors.Is(err, tt.wantError) {
+			if !errors.Is(err, tc.wantError) {
 				t.Errorf("got RemoveConstraint error = %v, want %v",
-					err, tt.wantError)
-			}
-
-			expectedCount := 0
-			expectedHandled := make(map[string]bool)
-			if tt.wantError == nil {
-				expectedCount = 1
-				expectedHandled = map[string]bool{"h1": true}
+					err, tc.wantError)
 			}
 
 			if r == nil {
 				t.Fatal("got RemoveConstraint() == nil, want non-nil")
 			}
 
-			if r.HandledCount() != expectedCount {
-				t.Errorf("HandledCount() = %v; want %v", r.HandledCount(), expectedCount)
-			}
-
-			if !reflect.DeepEqual(r.Handled, expectedHandled) {
-				t.Errorf("r.Handled = %v; want %v", r.Handled, expectedHandled)
+			if diff := cmp.Diff(tc.wantHandled, r.Handled, cmpopts.EquateEmpty()); diff != "" {
+				t.Error(diff)
 			}
 		})
 	}
@@ -965,126 +1023,385 @@ violation[{"msg": "msg"}] {
 }
 `
 
-	tc := []struct {
-		Name          string
-		Handler       TargetHandler
-		Template      *templates.ConstraintTemplate
-		ErrorExpected bool
-		InvAllowed    bool
+	tcs := []struct {
+		name          string
+		allowedFields []string
+		handler       TargetHandler
+		template      *templates.ConstraintTemplate
+		wantHandled   map[string]bool
+		wantError     error
 	}{
 		{
-			Name:          "Inventory Not Used",
-			Handler:       &badHandler{Name: "h1", HasLib: true},
-			Template:      createTemplate(name("fakes"), crdNames("Fakes"), targets("h1")),
-			ErrorExpected: false,
+			name:          "Inventory Not Used",
+			allowedFields: []string{},
+			handler:       &badHandler{Name: "h1", HasLib: true},
+			template:      createTemplate(name("fakes"), crdNames("Fakes"), targets("h1")),
+			wantHandled:   map[string]bool{"h1": true},
+			wantError:     nil,
 		},
 		{
-			Name:          "Inventory Used",
-			Handler:       &badHandler{Name: "h1", HasLib: true},
-			Template:      inventoryTempl,
-			ErrorExpected: true,
+			name:          "Inventory used but not allowed",
+			allowedFields: []string{},
+			handler:       &badHandler{Name: "h1", HasLib: true},
+			template:      inventoryTempl,
+			wantHandled:   nil,
+			wantError:     ErrInvalidConstraintTemplate,
 		},
 		{
-			Name:          "Inventory Used But Allowed",
-			Handler:       &badHandler{Name: "h1", HasLib: true},
-			Template:      inventoryTempl,
-			ErrorExpected: false,
-			InvAllowed:    true,
+			name:          "Inventory used and allowed",
+			allowedFields: []string{"inventory"},
+			handler:       &badHandler{Name: "h1", HasLib: true},
+			template:      inventoryTempl,
+			wantHandled:   map[string]bool{"h1": true},
+			wantError:     nil,
 		},
 	}
-	for _, tt := range tc {
-		t.Run(tt.Name, func(t *testing.T) {
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
 			d := local.New()
+
 			b, err := NewBackend(Driver(d))
-			if err != nil {
-				t.Fatalf("Could not create backend: %s", err)
-			}
-			f := AllowedDataFields()
-			if tt.InvAllowed {
-				f = AllowedDataFields("inventory")
-			}
-			c, err := b.NewClient(Targets(tt.Handler), f)
 			if err != nil {
 				t.Fatal(err)
 			}
-			r, err := c.AddTemplate(context.Background(), tt.Template)
-			if err != nil && !tt.ErrorExpected {
-				t.Errorf("err = %v; want nil", err)
+
+			c, err := b.NewClient(Targets(tc.handler), AllowedDataFields(tc.allowedFields...))
+			if err != nil {
+				t.Fatal(err)
 			}
-			if err == nil && tt.ErrorExpected {
-				t.Error("err = nil; want non-nil")
-			}
-			expectedCount := 0
-			expectedHandled := make(map[string]bool)
-			if !tt.ErrorExpected {
-				expectedCount = 1
-				expectedHandled = map[string]bool{"h1": true}
+
+			r, err := c.AddTemplate(context.Background(), tc.template)
+			if !errors.Is(err, tc.wantError) {
+				t.Fatalf("got AddTemplate() error = %v, want %v",
+					err, tc.wantError)
 			}
 
 			if r == nil {
 				t.Fatal("got AddTemplate() == nil, want non-nil")
 			}
-			if r.HandledCount() != expectedCount {
-				t.Errorf("HandledCount() = %v; want %v", r.HandledCount(), expectedCount)
-			}
-			if !reflect.DeepEqual(r.Handled, expectedHandled) {
-				t.Errorf("r.Handled = %v; want %v", r.Handled, expectedHandled)
+
+			if diff := cmp.Diff(tc.wantHandled, r.Handled, cmpopts.EquateEmpty()); diff != "" {
+				t.Error(diff)
 			}
 		})
 	}
 }
 
 func TestAllowedDataFieldsIntersection(t *testing.T) {
-	tc := []struct {
-		Name      string
-		Allowed   Opt
-		Expected  []string
-		wantError bool
+	tcs := []struct {
+		name      string
+		allowed   Opt
+		want      []string
+		wantError error
 	}{
 		{
-			Name:     "No AllowedDataFields specified",
-			Expected: []string{"inventory"},
+			name: "No AllowedDataFields specified",
+			want: []string{"inventory"},
 		},
 		{
-			Name:     "Empty AllowedDataFields Used",
-			Allowed:  AllowedDataFields(),
-			Expected: nil,
+			name:    "Empty AllowedDataFields Used",
+			allowed: AllowedDataFields(),
+			want:    nil,
 		},
 		{
-			Name:     "Inventory Used",
-			Allowed:  AllowedDataFields("inventory"),
-			Expected: []string{"inventory"},
+			name:    "Inventory Used",
+			allowed: AllowedDataFields("inventory"),
+			want:    []string{"inventory"},
 		},
 		{
-			Name:      "Invalid Data Field",
-			Allowed:   AllowedDataFields("no_overlap"),
-			Expected:  []string{},
-			wantError: true,
+			name:      "Invalid Data Field",
+			allowed:   AllowedDataFields("no_overlap"),
+			want:      []string{},
+			wantError: ErrCreatingClient,
 		},
 	}
-	for _, tt := range tc {
-		t.Run(tt.Name, func(t *testing.T) {
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
 			d := local.New()
+
 			b, err := NewBackend(Driver(d))
 			if err != nil {
 				t.Fatalf("Could not create backend: %s", err)
 			}
+
 			opts := []Opt{Targets(&badHandler{Name: "h1", HasLib: true})}
-			if tt.Allowed != nil {
-				opts = append(opts, tt.Allowed)
+			if tc.allowed != nil {
+				opts = append(opts, tc.allowed)
 			}
+
 			c, err := b.NewClient(opts...)
-			if tt.wantError {
-				if err == nil {
-					t.Fatalf("Expectd error, got nil")
-				}
+			if !errors.Is(err, tc.wantError) {
+				t.Fatalf("got NewClient() error = %v, want %v",
+					err, tc.wantError)
+			}
+
+			if tc.wantError != nil {
 				return
 			}
+
+			if diff := cmp.Diff(tc.want, c.allowedDataFields); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}
+
+func TestClient_CreateCRD(t *testing.T) {
+	testCases := []struct {
+		name     string
+		targets  []TargetHandler
+		template *templates.ConstraintTemplate
+		want     *apiextensions.CustomResourceDefinition
+		wantErr  error
+	}{
+		{
+			name:     "nil",
+			targets:  []TargetHandler{&badHandler{Name: "handler", HasLib: true}},
+			template: nil,
+			want:     nil,
+			wantErr:  ErrInvalidConstraintTemplate,
+		},
+		{
+			name:     "empty",
+			targets:  []TargetHandler{&badHandler{Name: "handler", HasLib: true}},
+			template: &templates.ConstraintTemplate{},
+			want:     nil,
+			wantErr:  ErrInvalidConstraintTemplate,
+		},
+		{
+			name:    "no CRD kind",
+			targets: []TargetHandler{&handler{}},
+			template: &templates.ConstraintTemplate{
+				ObjectMeta: v1.ObjectMeta{Name: "foo"},
+			},
+			want:    nil,
+			wantErr: ErrInvalidConstraintTemplate,
+		},
+		{
+			name:    "name-kind mismatch",
+			targets: []TargetHandler{&badHandler{Name: "handler", HasLib: true}},
+			template: &templates.ConstraintTemplate{
+				ObjectMeta: v1.ObjectMeta{Name: "foo"},
+				Spec: templates.ConstraintTemplateSpec{
+					CRD: templates.CRD{
+						Spec: templates.CRDSpec{
+							Names: templates.Names{
+								Kind: "Bar",
+							},
+						},
+					},
+					Targets: []templates.Target{{
+						Target: "handler",
+						Rego: `package foo
+
+violation[msg] {msg := "always"}`,
+					}},
+				},
+			},
+			want:    nil,
+			wantErr: ErrInvalidConstraintTemplate,
+		},
+		{
+			name:    "no targets",
+			targets: []TargetHandler{&badHandler{Name: "handler", HasLib: true}},
+			template: &templates.ConstraintTemplate{
+				ObjectMeta: v1.ObjectMeta{Name: "foo"},
+				Spec: templates.ConstraintTemplateSpec{
+					CRD: templates.CRD{
+						Spec: templates.CRDSpec{
+							Names: templates.Names{
+								Kind: "Foo",
+							},
+						},
+					},
+				},
+			},
+			want:    nil,
+			wantErr: ErrInvalidConstraintTemplate,
+		},
+		{
+			name:    "wrong target",
+			targets: []TargetHandler{&badHandler{Name: "handler.1", HasLib: true}},
+			template: &templates.ConstraintTemplate{
+				ObjectMeta: v1.ObjectMeta{Name: "foo"},
+				Spec: templates.ConstraintTemplateSpec{
+					CRD: templates.CRD{
+						Spec: templates.CRDSpec{
+							Names: templates.Names{
+								Kind: "Foo",
+							},
+						},
+					},
+					Targets: []templates.Target{{
+						Target: "handler.2",
+					}},
+				},
+			},
+			want:    nil,
+			wantErr: ErrInvalidConstraintTemplate,
+		},
+		{
+			name:    "no rego",
+			targets: []TargetHandler{&badHandler{Name: "handler", HasLib: true}},
+			template: &templates.ConstraintTemplate{
+				ObjectMeta: v1.ObjectMeta{Name: "foo"},
+				Spec: templates.ConstraintTemplateSpec{
+					CRD: templates.CRD{
+						Spec: templates.CRDSpec{
+							Names: templates.Names{
+								Kind: "Foo",
+							},
+						},
+					},
+					Targets: []templates.Target{{
+						Target: "handler",
+					}},
+				},
+			},
+			want:    nil,
+			wantErr: ErrInvalidConstraintTemplate,
+		},
+		{
+			name:    "empty rego package",
+			targets: []TargetHandler{&badHandler{Name: "handler", HasLib: true}},
+			template: &templates.ConstraintTemplate{
+				ObjectMeta: v1.ObjectMeta{Name: "foo"},
+				Spec: templates.ConstraintTemplateSpec{
+					CRD: templates.CRD{
+						Spec: templates.CRDSpec{
+							Names: templates.Names{
+								Kind: "Foo",
+							},
+						},
+					},
+					Targets: []templates.Target{{
+						Target: "handler",
+						Rego:   `package foo`,
+					}},
+				},
+			},
+			want:    nil,
+			wantErr: ErrInvalidConstraintTemplate,
+		},
+		{
+			name: "multiple targets",
+			targets: []TargetHandler{
+				&badHandler{Name: "handler", HasLib: true},
+				&badHandler{Name: "handler.2", HasLib: true},
+			},
+			template: &templates.ConstraintTemplate{
+				ObjectMeta: v1.ObjectMeta{Name: "foo"},
+				Spec: templates.ConstraintTemplateSpec{
+					CRD: templates.CRD{
+						Spec: templates.CRDSpec{
+							Names: templates.Names{
+								Kind: "Foo",
+							},
+						},
+					},
+					Targets: []templates.Target{{
+						Target: "handler",
+						Rego: `package foo
+
+violation[msg] {msg := "always"}`,
+					}, {
+						Target: "handler.2",
+						Rego: `package foo
+
+violation[msg] {msg := "always"}`,
+					}},
+				},
+			},
+			want:    nil,
+			wantErr: ErrInvalidConstraintTemplate,
+		},
+		{
+			name:    "minimal working",
+			targets: []TargetHandler{&badHandler{Name: "handler", HasLib: true}},
+			template: &templates.ConstraintTemplate{
+				ObjectMeta: v1.ObjectMeta{Name: "foo"},
+				Spec: templates.ConstraintTemplateSpec{
+					CRD: templates.CRD{
+						Spec: templates.CRDSpec{
+							Names: templates.Names{
+								Kind: "Foo",
+							},
+						},
+					},
+					Targets: []templates.Target{{
+						Target: "handler",
+						Rego: `package foo
+
+violation[msg] {msg := "always"}`,
+					}},
+				},
+			},
+			want: &apiextensions.CustomResourceDefinition{
+				ObjectMeta: v1.ObjectMeta{
+					Name:   "foo.constraints.gatekeeper.sh",
+					Labels: map[string]string{"gatekeeper.sh/constraint": "yes"},
+				},
+				Spec: apiextensions.CustomResourceDefinitionSpec{
+					Group:   "constraints.gatekeeper.sh",
+					Version: "v1beta1",
+					Names: apiextensions.CustomResourceDefinitionNames{
+						Plural:     "foo",
+						Singular:   "foo",
+						Kind:       "Foo",
+						ListKind:   "FooList",
+						Categories: []string{"constraint", "constraints"},
+					},
+					Scope: apiextensions.ClusterScoped,
+					Subresources: &apiextensions.CustomResourceSubresources{
+						Status: &apiextensions.CustomResourceSubresourceStatus{},
+					},
+					Versions: []apiextensions.CustomResourceDefinitionVersion{{
+						Name: "v1beta1", Served: true, Storage: true,
+					}, {
+						Name: "v1alpha1", Served: true,
+					}},
+					Conversion: &apiextensions.CustomResourceConversion{
+						Strategy: apiextensions.NoneConverter,
+					},
+					PreserveUnknownFields: pointer.BoolPtr(false),
+				},
+				Status: apiextensions.CustomResourceDefinitionStatus{
+					StoredVersions: []string{"v1beta1"},
+				},
+			},
+			wantErr: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			d := local.New()
+
+			b, err := NewBackend(Driver(d))
 			if err != nil {
 				t.Fatal(err)
 			}
-			if !reflect.DeepEqual(c.allowedDataFields, tt.Expected) {
-				t.Errorf("c.allowedDataFields = %v; want %v", c.allowedDataFields, tt.Expected)
+
+			c, err := b.NewClient(Targets(tc.targets...))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			t.Log(c.targets)
+
+			got, err := c.CreateCRD(ctx, tc.template)
+
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("got CreateTemplate() error = %v, want %v",
+					err, tc.wantErr)
+			}
+
+			if diff := cmp.Diff(tc.want, got,
+				cmpopts.IgnoreFields(apiextensions.CustomResourceDefinitionSpec{}, "Validation")); diff != "" {
+				t.Error(diff)
 			}
 		})
 	}

--- a/constraint/pkg/client/crd_helpers.go
+++ b/constraint/pkg/client/crd_helpers.go
@@ -28,18 +28,18 @@ func validateTargets(templ *templates.ConstraintTemplate) error {
 	targets := templ.Spec.Targets
 	if targets == nil {
 		return fmt.Errorf(`%w: field "targets" not specified in ConstraintTemplate spec`,
-			errInvalidConstraintTemplate)
+			ErrInvalidConstraintTemplate)
 	}
 
 	switch len(targets) {
 	case 0:
 		return fmt.Errorf("%w: no targets specified: ConstraintTemplate must specify one target",
-			errInvalidConstraintTemplate)
+			ErrInvalidConstraintTemplate)
 	case 1:
 		return nil
 	default:
 		return fmt.Errorf("%w: multi-target templates are not currently supported",
-			errInvalidConstraintTemplate)
+			ErrInvalidConstraintTemplate)
 	}
 }
 
@@ -181,23 +181,23 @@ func (h *crdHelper) validateCR(cr *unstructured.Unstructured, crd *apiextensions
 	}
 
 	if errs := apivalidation.IsDNS1123Subdomain(cr.GetName()); len(errs) != 0 {
-		return fmt.Errorf("%w: invalid Name: %q",
-			errInvalidConstraint, strings.Join(errs, "\n"))
+		return fmt.Errorf("%w: invalid name: %q",
+			ErrInvalidConstraint, strings.Join(errs, "\n"))
 	}
 
 	if cr.GetKind() != crd.Spec.Names.Kind {
 		return fmt.Errorf("%w: wrong kind %q for constraint %q; want %q",
-			errInvalidConstraint, cr.GetName(), cr.GetKind(), crd.Spec.Names.Kind)
+			ErrInvalidConstraint, cr.GetName(), cr.GetKind(), crd.Spec.Names.Kind)
 	}
 
 	if cr.GroupVersionKind().Group != constraintGroup {
 		return fmt.Errorf("%w: unsupported group %q for constraint %q; allowed group: %q",
-			errInvalidConstraint, cr.GetName(), cr.GroupVersionKind().Group, constraintGroup)
+			ErrInvalidConstraint, cr.GetName(), cr.GroupVersionKind().Group, constraintGroup)
 	}
 
 	if !supportedVersions[cr.GroupVersionKind().Version] {
 		return fmt.Errorf("%w: unsupported version %q for Constraint %q; supported versions: %v",
-			errInvalidConstraint, cr.GroupVersionKind().Version, cr.GetName(), supportedVersions)
+			ErrInvalidConstraint, cr.GroupVersionKind().Version, cr.GetName(), supportedVersions)
 	}
 	return nil
 }

--- a/constraint/pkg/client/crd_helpers.go
+++ b/constraint/pkg/client/crd_helpers.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -16,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	apivalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/pointer"
 )
 
 var supportedVersions = map[string]bool{
@@ -27,16 +27,19 @@ var supportedVersions = map[string]bool{
 func validateTargets(templ *templates.ConstraintTemplate) error {
 	targets := templ.Spec.Targets
 	if targets == nil {
-		return errors.New(`field "targets" not specified in ConstraintTemplate spec`)
+		return fmt.Errorf(`%w: field "targets" not specified in ConstraintTemplate spec`,
+			errInvalidConstraintTemplate)
 	}
 
 	switch len(targets) {
 	case 0:
-		return errors.New("no targets specified: ConstraintTemplate must specify one target")
+		return fmt.Errorf("%w: no targets specified: ConstraintTemplate must specify one target",
+			errInvalidConstraintTemplate)
 	case 1:
 		return nil
 	default:
-		return errors.New("multi-target templates are not currently supported")
+		return fmt.Errorf("%w: multi-target templates are not currently supported",
+			errInvalidConstraintTemplate)
 	}
 }
 
@@ -53,7 +56,6 @@ func (h *crdHelper) createSchema(templ *templates.ConstraintTemplate, target Mat
 		props["parameters"] = internalSchema
 	}
 
-	trueBool := true
 	schema := &apiextensions.JSONSchemaProps{
 		Type: "object",
 		Properties: map[string]apiextensions.JSONSchemaProps{
@@ -71,7 +73,7 @@ func (h *crdHelper) createSchema(templ *templates.ConstraintTemplate, target Mat
 				Properties: props,
 			},
 			"status": {
-				XPreserveUnknownFields: &trueBool,
+				XPreserveUnknownFields: pointer.BoolPtr(true),
 			},
 		},
 	}
@@ -97,10 +99,9 @@ func newCRDHelper() (*crdHelper, error) {
 func (h *crdHelper) createCRD(
 	templ *templates.ConstraintTemplate,
 	schema *apiextensions.JSONSchemaProps) (*apiextensions.CustomResourceDefinition, error) {
-	falseBool := false
 	crd := &apiextensions.CustomResourceDefinition{
 		Spec: apiextensions.CustomResourceDefinitionSpec{
-			PreserveUnknownFields: &falseBool,
+			PreserveUnknownFields: pointer.Bool(false),
 			Group:                 constraintGroup,
 			Names: apiextensions.CustomResourceDefinitionNames{
 				Kind:       templ.Spec.CRD.Spec.Names.Kind,
@@ -178,17 +179,25 @@ func (h *crdHelper) validateCR(cr *unstructured.Unstructured, crd *apiextensions
 	if err := validation.ValidateCustomResource(field.NewPath(""), cr, validator); err != nil {
 		return err.ToAggregate()
 	}
+
 	if errs := apivalidation.IsDNS1123Subdomain(cr.GetName()); len(errs) != 0 {
-		return fmt.Errorf("invalid Name: %s", strings.Join(errs, "\n"))
+		return fmt.Errorf("%w: invalid Name: %q",
+			errInvalidConstraint, strings.Join(errs, "\n"))
 	}
+
 	if cr.GetKind() != crd.Spec.Names.Kind {
-		return fmt.Errorf("wrong kind for constraint %s. Have %s, want %s", cr.GetName(), cr.GetKind(), crd.Spec.Names.Kind)
+		return fmt.Errorf("%w: wrong kind %q for constraint %q; want %q",
+			errInvalidConstraint, cr.GetName(), cr.GetKind(), crd.Spec.Names.Kind)
 	}
+
 	if cr.GroupVersionKind().Group != constraintGroup {
-		return fmt.Errorf("wrong group for constraint %s. Have %s, want %s", cr.GetName(), cr.GroupVersionKind().Group, constraintGroup)
+		return fmt.Errorf("%w: unsupported group %q for constraint %q; allowed group: %q",
+			errInvalidConstraint, cr.GetName(), cr.GroupVersionKind().Group, constraintGroup)
 	}
+
 	if !supportedVersions[cr.GroupVersionKind().Version] {
-		return fmt.Errorf("wrong version for constraint %s. Have %s, supported: %v", cr.GetName(), cr.GroupVersionKind().Version, supportedVersions)
+		return fmt.Errorf("%w: unsupported version %q for Constraint %q; supported versions: %v",
+			errInvalidConstraint, cr.GroupVersionKind().Version, cr.GetName(), supportedVersions)
 	}
 	return nil
 }

--- a/constraint/pkg/client/crd_helpers.go
+++ b/constraint/pkg/client/crd_helpers.go
@@ -117,7 +117,7 @@ func (h *crdHelper) createCRD(
 			Validation: &apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: schema,
 			},
-			Scope:   "Cluster",
+			Scope:   apiextensions.ClusterScoped,
 			Version: v1beta1.SchemeGroupVersion.Version,
 			Subresources: &apiextensions.CustomResourceSubresources{
 				Status: &apiextensions.CustomResourceSubresourceStatus{},

--- a/constraint/pkg/client/crd_helpers_test.go
+++ b/constraint/pkg/client/crd_helpers_test.go
@@ -438,7 +438,7 @@ func TestCRValidation(t *testing.T) {
 			ErrorExpected: false,
 		},
 		{
-			Name: "No Name",
+			Name: "No name",
 			Template: createTemplate(
 				name("SomeName"),
 				crdNames("Horse"),

--- a/constraint/pkg/client/crd_helpers_test.go
+++ b/constraint/pkg/client/crd_helpers_test.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8schema "k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/pointer"
 )
 
 // helpers for creating a ConstraintTemplate for test
@@ -84,8 +85,7 @@ func createTestTargetHandler(args ...targetHandlerArg) MatchSchemaProvider {
 	h := &testTargetHandler{}
 
 	// The default matchSchema is empty, and thus lacks type information
-	trueBool := true
-	h.matchSchema.XPreserveUnknownFields = &trueBool
+	h.matchSchema.XPreserveUnknownFields = pointer.Bool(true)
 
 	for _, arg := range args {
 		arg(h)
@@ -104,8 +104,7 @@ type propMap map[string]apiextensions.JSONSchemaProps
 // prop currently expects 0 or 1 prop map. More is unsupported.
 func prop(pm ...map[string]apiextensions.JSONSchemaProps) apiextensions.JSONSchemaProps {
 	if len(pm) == 0 {
-		trueBool := true
-		return apiextensions.JSONSchemaProps{XPreserveUnknownFields: &trueBool}
+		return apiextensions.JSONSchemaProps{XPreserveUnknownFields: pointer.Bool(true)}
 	}
 	return apiextensions.JSONSchemaProps{Type: "object", Properties: pm[0]}
 }
@@ -117,7 +116,6 @@ func tProp(t string) apiextensions.JSONSchemaProps {
 
 func expectedSchema(pm propMap) *apiextensions.JSONSchemaProps {
 	pm["enforcementAction"] = apiextensions.JSONSchemaProps{Type: "string"}
-	trueBool := true
 	p := prop(
 		propMap{
 			"metadata": prop(propMap{
@@ -127,7 +125,7 @@ func expectedSchema(pm propMap) *apiextensions.JSONSchemaProps {
 				},
 			}),
 			"spec":   prop(pm),
-			"status": {XPreserveUnknownFields: &trueBool},
+			"status": {XPreserveUnknownFields: pointer.Bool(true)},
 		},
 	)
 	return &p

--- a/constraint/pkg/client/error_map.go
+++ b/constraint/pkg/client/error_map.go
@@ -1,0 +1,51 @@
+package client
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// ErrorMap is a map from targets to the error the target returned.
+type ErrorMap map[string]error
+
+// Error implements error.
+//
+// Uses a pointer receiver to avoid potential errors.Is() bugs.
+func (e *ErrorMap) Error() string {
+	b := &strings.Builder{}
+
+	// Make printed error deterministic by sorting keys.
+	keys := make([]string, len(*e))
+	i := 0
+	for k := range *e {
+		keys[i] = k
+		i++
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		b.WriteString(fmt.Sprintf("%s: %s\n", k, (*e)[k]))
+	}
+	return b.String()
+}
+
+func (e *ErrorMap) Is(target error) bool {
+	t, ok := target.(*ErrorMap)
+	if !ok {
+		return false
+	}
+
+	if len(*e) != len(*t) {
+		return false
+	}
+
+	for k := range *e {
+		if !errors.Is((*e)[k], (*t)[k]) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/constraint/pkg/client/errors.go
+++ b/constraint/pkg/client/errors.go
@@ -3,6 +3,7 @@ package client
 import (
 	"errors"
 	"fmt"
+	"strings"
 )
 
 var (
@@ -57,4 +58,28 @@ func (e *MissingTemplateError) Error() string {
 
 func NewMissingTemplateError(mapKey string) error {
 	return &MissingTemplateError{mapKey}
+}
+
+// Errors is a list of error.
+//
+// Deprecated: Use a structured result type if it is important to disambiguate
+// errors (for tests or error handling). Otherwise,.
+type Errors []error
+
+// Errors implements error.
+var _ error = Errors{}
+
+// Error implements error.
+func (errs Errors) Error() string {
+	return ToError(errs)
+}
+
+// ToError combines multiple errors into a single error message. The original
+// errors cannot be extracted (for tests or programmatic error handling).
+func ToError(errs []error) string {
+	s := make([]string, len(errs))
+	for _, e := range errs {
+		s = append(s, e.Error())
+	}
+	return strings.Join(s, "\n")
 }

--- a/constraint/pkg/client/errors.go
+++ b/constraint/pkg/client/errors.go
@@ -6,8 +6,11 @@ import (
 )
 
 var (
-	errCreatingBackend = errors.New("unable to create backend")
-	errCreatingClient  = errors.New("unable to create client")
+	errCreatingBackend           = errors.New("unable to create backend")
+	errCreatingClient            = errors.New("unable to create client")
+	errInvalidConstraintTemplate = errors.New("invalid ConstraintTemplate")
+	errInvalidConstraint         = errors.New("invalid Constraint")
+	errInvalidModule             = errors.New("invalid module")
 )
 
 type UnrecognizedConstraintError struct {
@@ -25,11 +28,6 @@ func IsUnrecognizedConstraintError(e error) bool {
 
 func NewUnrecognizedConstraintError(text string) error {
 	return &UnrecognizedConstraintError{text}
-}
-
-func IsMissingConstraintError(e error) bool {
-	_, ok := e.(*MissingConstraintError)
-	return ok
 }
 
 type MissingConstraintError struct {

--- a/constraint/pkg/client/errors.go
+++ b/constraint/pkg/client/errors.go
@@ -2,62 +2,24 @@ package client
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 )
 
 var (
-	errCreatingBackend           = errors.New("unable to create backend")
-	errCreatingClient            = errors.New("unable to create client")
-	errInvalidConstraintTemplate = errors.New("invalid ConstraintTemplate")
-	errInvalidConstraint         = errors.New("invalid Constraint")
-	errInvalidModule             = errors.New("invalid module")
+	ErrCreatingBackend           = errors.New("unable to create backend")
+	ErrCreatingClient            = errors.New("unable to create client")
+	ErrInvalidConstraintTemplate = errors.New("invalid ConstraintTemplate")
+	ErrInvalidConstraint         = errors.New("invalid Constraint")
+	ErrMissingConstraintTemplate = errors.New("missing ConstraintTemplate")
+	ErrMissingConstraint         = errors.New("missing Constraint")
+	ErrInvalidModule             = errors.New("invalid module")
 )
 
-type UnrecognizedConstraintError struct {
-	s string
-}
-
-func (e *UnrecognizedConstraintError) Error() string {
-	return fmt.Sprintf("Constraint kind %s is not recognized", e.s)
-}
-
-func IsUnrecognizedConstraintError(e error) bool {
-	_, ok := e.(*UnrecognizedConstraintError)
-	return ok
-}
-
-func NewUnrecognizedConstraintError(text string) error {
-	return &UnrecognizedConstraintError{text}
-}
-
-type MissingConstraintError struct {
-	s string
-}
-
-func (e *MissingConstraintError) Error() string {
-	return fmt.Sprintf("Constraint kind %s is not recognized", e.s)
-}
-
-func NewMissingConstraintError(subPath string) error {
-	return &MissingConstraintError{subPath}
-}
-
-func IsMissingTemplateError(e error) bool {
-	_, ok := e.(*MissingTemplateError)
-	return ok
-}
-
-type MissingTemplateError struct {
-	s string
-}
-
-func (e *MissingTemplateError) Error() string {
-	return fmt.Sprintf("Constraint kind %s is not recognized", e.s)
-}
-
-func NewMissingTemplateError(mapKey string) error {
-	return &MissingTemplateError{mapKey}
+// IsUnrecognizedConstraintError returns true if err is an ErrMissingConstraint.
+//
+// Deprecated: Use errors.Is(err, ErrMissingConstraint) instead.
+func IsUnrecognizedConstraintError(err error) bool {
+	return errors.Is(err, ErrMissingConstraint)
 }
 
 // Errors is a list of error.

--- a/constraint/pkg/client/errors.go
+++ b/constraint/pkg/client/errors.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"errors"
-	"strings"
 )
 
 var (
@@ -20,28 +19,4 @@ var (
 // Deprecated: Use errors.Is(err, ErrMissingConstraint) instead.
 func IsUnrecognizedConstraintError(err error) bool {
 	return errors.Is(err, ErrMissingConstraint)
-}
-
-// Errors is a list of error.
-//
-// Deprecated: Use a structured result type if it is important to disambiguate
-// errors (for tests or error handling). Otherwise,.
-type Errors []error
-
-// Errors implements error.
-var _ error = Errors{}
-
-// Error implements error.
-func (errs Errors) Error() string {
-	return ToError(errs)
-}
-
-// ToError combines multiple errors into a single error message. The original
-// errors cannot be extracted (for tests or programmatic error handling).
-func ToError(errs []error) string {
-	s := make([]string, len(errs))
-	for _, e := range errs {
-		s = append(s, e.Error())
-	}
-	return strings.Join(s, "\n")
 }

--- a/constraint/pkg/client/errors.go
+++ b/constraint/pkg/client/errors.go
@@ -1,34 +1,14 @@
 package client
 
 import (
+	"errors"
 	"fmt"
-	"strings"
 )
 
-// Errors is a list of error.
-type Errors []error
-
-// Errors implements error.
-var _ error = Errors{}
-
-// Error implements error.
-func (errs Errors) Error() string {
-	s := make([]string, len(errs))
-	for _, e := range errs {
-		s = append(s, e.Error())
-	}
-	return strings.Join(s, "\n")
-}
-
-type ErrorMap map[string]error
-
-func (e ErrorMap) Error() string {
-	b := &strings.Builder{}
-	for k, v := range e {
-		_, _ = fmt.Fprintf(b, "%s: %s\n", k, v)
-	}
-	return b.String()
-}
+var (
+	errCreatingBackend = errors.New("unable to create backend")
+	errCreatingClient  = errors.New("unable to create client")
+)
 
 type UnrecognizedConstraintError struct {
 	s string

--- a/constraint/pkg/client/query_opts.go
+++ b/constraint/pkg/client/query_opts.go
@@ -1,0 +1,13 @@
+package client
+
+type queryCfg struct {
+	enableTracing bool
+}
+
+type QueryOpt func(*queryCfg)
+
+func Tracing(enabled bool) QueryOpt {
+	return func(cfg *queryCfg) {
+		cfg.enableTracing = enabled
+	}
+}

--- a/constraint/pkg/client/rego_helpers.go
+++ b/constraint/pkg/client/rego_helpers.go
@@ -21,7 +21,7 @@ func parseModule(path, rego string) (*ast.Module, error) {
 
 	if module == nil {
 		return nil, fmt.Errorf("%w: module %q is empty",
-			errInvalidModule, path)
+			ErrInvalidModule, path)
 	}
 
 	return module, nil
@@ -59,7 +59,7 @@ func requireModuleRules(module *ast.Module, requiredRules map[string]struct{}) e
 
 	if len(missing) > 0 {
 		return fmt.Errorf("%w: missing required rules: %v",
-			errInvalidModule, missing)
+			ErrInvalidModule, missing)
 	}
 
 	return nil

--- a/constraint/pkg/client/rego_helpers.go
+++ b/constraint/pkg/client/rego_helpers.go
@@ -1,8 +1,8 @@
 package client
 
 import (
-	"errors"
 	"fmt"
+	"sort"
 
 	"github.com/open-policy-agent/opa/ast"
 )
@@ -18,9 +18,12 @@ func parseModule(path, rego string) (*ast.Module, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	if module == nil {
-		return nil, errors.New("empty module")
+		return nil, fmt.Errorf("%w: module %q is empty",
+			errInvalidModule, path)
 	}
+
 	return module, nil
 }
 
@@ -30,24 +33,33 @@ func rewriteModulePackage(path string, module *ast.Module) error {
 	if err != nil {
 		return err
 	}
+
 	packageRef := ast.Ref([]*ast.Term{ast.VarTerm("data")})
 	newPath := packageRef.Extend(pathParts)
 	module.Package.Path = newPath
 	return nil
 }
 
-// requireRulesModule makes sure the listed rules are specified.
-func requireRulesModule(module *ast.Module, requiredRules map[string]struct{}) error {
+// requireModuleRules makes sure the module contains all of the specified
+// requiredRules.
+func requireModuleRules(module *ast.Module, requiredRules map[string]struct{}) error {
 	ruleSets := make(map[string]struct{}, len(module.Rules))
 	for _, rule := range module.Rules {
 		ruleSets[string(rule.Head.Name)] = struct{}{}
 	}
 
+	var missing []string
 	for name := range requiredRules {
 		_, ok := ruleSets[name]
 		if !ok {
-			return fmt.Errorf("missing required rule: %s", name)
+			missing = append(missing, name)
 		}
+	}
+	sort.Strings(missing)
+
+	if len(missing) > 0 {
+		return fmt.Errorf("%w: missing required rules: %v",
+			errInvalidModule, missing)
 	}
 
 	return nil

--- a/constraint/pkg/client/rego_helpers.go
+++ b/constraint/pkg/client/rego_helpers.go
@@ -43,16 +43,12 @@ func requireRulesModule(module *ast.Module, requiredRules map[string]struct{}) e
 		ruleSets[string(rule.Head.Name)] = struct{}{}
 	}
 
-	var errs Errors
 	for name := range requiredRules {
 		_, ok := ruleSets[name]
 		if !ok {
-			errs = append(errs, fmt.Errorf("missing required rule: %s", name))
-			continue
+			return fmt.Errorf("missing required rule: %s", name)
 		}
 	}
-	if len(errs) != 0 {
-		return errs
-	}
+
 	return nil
 }

--- a/constraint/pkg/client/rego_helpers_test.go
+++ b/constraint/pkg/client/rego_helpers_test.go
@@ -55,7 +55,7 @@ func TestRequireRules(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			mod, err := parseModule("foo", tt.Rego)
 			if err == nil {
-				err = requireRulesModule(mod, tt.RequiredRules)
+				err = requireModuleRules(mod, tt.RequiredRules)
 			}
 
 			if (err == nil) && tt.ErrorExpected {

--- a/constraint/pkg/core/constraints/constraints.go
+++ b/constraint/pkg/core/constraints/constraints.go
@@ -10,16 +10,8 @@ import (
 // ignores status and metadata because neither are relevant as to how a
 // constraint is enforced. It is assumed that the author is comparing
 // two constraints with the same GVK/namespace/name.
-//
-// Returns if either or both spec fields are empty.
 func SemanticEqual(c1 *unstructured.Unstructured, c2 *unstructured.Unstructured) bool {
-	s1, exists, err := unstructured.NestedMap(c1.Object, "spec")
-	if err != nil || !exists {
-		return false
-	}
-	s2, exists, err := unstructured.NestedMap(c2.Object, "spec")
-	if err != nil || !exists {
-		return false
-	}
+	s1 := c1.Object["spec"]
+	s2 := c2.Object["spec"]
 	return reflect.DeepEqual(s1, s2)
 }

--- a/constraint/pkg/core/constraints/constraints.go
+++ b/constraint/pkg/core/constraints/constraints.go
@@ -11,6 +11,14 @@ import (
 // constraint is enforced. It is assumed that the author is comparing
 // two constraints with the same GVK/namespace/name.
 func SemanticEqual(c1 *unstructured.Unstructured, c2 *unstructured.Unstructured) bool {
+	if c1 == c2 {
+		return true
+	}
+
+	if (c1 == nil) != (c2 == nil) {
+		return false
+	}
+
 	s1 := c1.Object["spec"]
 	s2 := c2.Object["spec"]
 	return reflect.DeepEqual(s1, s2)

--- a/constraint/pkg/core/constraints/constraints.go
+++ b/constraint/pkg/core/constraints/constraints.go
@@ -10,6 +10,8 @@ import (
 // ignores status and metadata because neither are relevant as to how a
 // constraint is enforced. It is assumed that the author is comparing
 // two constraints with the same GVK/namespace/name.
+//
+// Returns if either or both spec fields are empty.
 func SemanticEqual(c1 *unstructured.Unstructured, c2 *unstructured.Unstructured) bool {
 	s1, exists, err := unstructured.NestedMap(c1.Object, "spec")
 	if err != nil || !exists {

--- a/constraint/pkg/core/constraints/constraints.go
+++ b/constraint/pkg/core/constraints/constraints.go
@@ -11,12 +11,8 @@ import (
 // constraint is enforced. It is assumed that the author is comparing
 // two constraints with the same GVK/namespace/name.
 func SemanticEqual(c1 *unstructured.Unstructured, c2 *unstructured.Unstructured) bool {
-	if c1 == c2 {
-		return true
-	}
-
-	if (c1 == nil) != (c2 == nil) {
-		return false
+	if c1 == nil || c2 == nil {
+		return c1 == c2
 	}
 
 	s1 := c1.Object["spec"]

--- a/constraint/pkg/core/constraints/constraints_test.go
+++ b/constraint/pkg/core/constraints/constraints_test.go
@@ -14,6 +14,20 @@ func TestSemanticEqual(t *testing.T) {
 		want bool
 	}{
 		{
+			name: "nil Constraints",
+			c1:   nil,
+			c2:   nil,
+			want: true,
+		},
+		{
+			name: "nil and non-nil Constraints",
+			c1:   nil,
+			c2: &unstructured.Unstructured{
+				Object: map[string]interface{}{},
+			},
+			want: false,
+		},
+		{
 			name: "empty Constraints",
 			c1: &unstructured.Unstructured{
 				Object: map[string]interface{}{},

--- a/constraint/pkg/core/constraints/constraints_test.go
+++ b/constraint/pkg/core/constraints/constraints_test.go
@@ -1,0 +1,109 @@
+package constraints
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestSemanticEqual(t *testing.T) {
+	testCases := []struct {
+		name string
+		c1   *unstructured.Unstructured
+		c2   *unstructured.Unstructured
+		want bool
+	}{
+		{
+			name: "empty Constraints",
+			c1:   &unstructured.Unstructured{
+				Object: map[string]interface{}{},
+			},
+			c2:   &unstructured.Unstructured{
+				Object: map[string]interface{}{},
+			},
+			want: true,
+		},
+		{
+			name: "one empty Constraint",
+			c1: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": "a",
+				},
+			},
+			c2:   &unstructured.Unstructured{
+				Object: map[string]interface{}{},
+			},
+			want: false,
+		},
+		{
+			name: "equal Constraints",
+			c1: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": "a",
+				},
+			},
+			c2: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": "a",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "unequal Constraints",
+			c1: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": "a",
+				},
+			},
+			c2: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": "b",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "equal Constraints map",
+			c1: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{"a": "b"},
+				},
+			},
+			c2: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{"a": "b"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "unequal Constraints",
+			c1: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{"a": "b"},
+				},
+			},
+			c2: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{"c": "d"},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := SemanticEqual(tc.c1, tc.c2)
+			if got != tc.want {
+				t.Fatalf("got SemanticEqual(c1, c2) = %v, want %v", got, tc.want)
+			}
+
+			got2 := SemanticEqual(tc.c2, tc.c1)
+			if got2 != tc.want {
+				t.Fatalf("got SemanticEqual(c2, c1) = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/constraint/pkg/core/constraints/constraints_test.go
+++ b/constraint/pkg/core/constraints/constraints_test.go
@@ -15,10 +15,10 @@ func TestSemanticEqual(t *testing.T) {
 	}{
 		{
 			name: "empty Constraints",
-			c1:   &unstructured.Unstructured{
+			c1: &unstructured.Unstructured{
 				Object: map[string]interface{}{},
 			},
-			c2:   &unstructured.Unstructured{
+			c2: &unstructured.Unstructured{
 				Object: map[string]interface{}{},
 			},
 			want: true,
@@ -30,7 +30,7 @@ func TestSemanticEqual(t *testing.T) {
 					"spec": "a",
 				},
 			},
-			c2:   &unstructured.Unstructured{
+			c2: &unstructured.Unstructured{
 				Object: map[string]interface{}{},
 			},
 			want: false,

--- a/constraint/pkg/schema/transform.go
+++ b/constraint/pkg/schema/transform.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/utils/pointer"
 )
 
 // AddPreserveUnknownFields recurses through an *apiextensionsv1.JSONSchemaProps
@@ -29,17 +30,15 @@ func AddPreserveUnknownFields(sch *apiextensionsv1.JSONSchemaProps) error {
 	// An object can have values not described in the schema.  A blank Type could be anything,
 	// including an object, so we add x-kubernetes-preserve-unknown-fields: true to both.
 	case "", "object":
-		tr := true
-		sch.XPreserveUnknownFields = &tr
+		sch.XPreserveUnknownFields = pointer.Bool(true)
 	case "array":
 		// If the type is array, the schema of the array's items must be structural.  If the schema
 		// is undefined, we must add a blank one with x-kubernetes-preserve-unknown-fields to meet
 		// this structural item schema requirement.
 		if sch.Items == nil || (sch.Items.Schema == nil && sch.Items.JSONSchemas == nil) {
-			tr := true
 			sch.Items = &apiextensionsv1.JSONSchemaPropsOrArray{
 				Schema: &apiextensionsv1.JSONSchemaProps{
-					XPreserveUnknownFields: &tr,
+					XPreserveUnknownFields: pointer.Bool(true),
 				},
 			}
 		}

--- a/constraint/pkg/schema/transform_test.go
+++ b/constraint/pkg/schema/transform_test.go
@@ -21,10 +21,10 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/utils/pointer"
 )
 
 func TestAddPreserveUnknownFields(t *testing.T) {
-	trueBool := true
 	testCases := []struct {
 		name  string
 		v     *apiextensionsv1.JSONSchemaProps
@@ -35,7 +35,7 @@ func TestAddPreserveUnknownFields(t *testing.T) {
 			name: "no information",
 			v:    &apiextensionsv1.JSONSchemaProps{},
 			exp: &apiextensionsv1.JSONSchemaProps{
-				XPreserveUnknownFields: &trueBool,
+				XPreserveUnknownFields: pointer.Bool(true),
 			},
 		},
 		{
@@ -44,17 +44,17 @@ func TestAddPreserveUnknownFields(t *testing.T) {
 				Properties: nil,
 			},
 			exp: &apiextensionsv1.JSONSchemaProps{
-				XPreserveUnknownFields: &trueBool,
+				XPreserveUnknownFields: pointer.Bool(true),
 				Properties:             nil,
 			},
 		},
 		{
 			name: "x-kubernetes-preserve-unknown-fields is present already and true",
 			v: &apiextensionsv1.JSONSchemaProps{
-				XPreserveUnknownFields: &trueBool,
+				XPreserveUnknownFields: pointer.Bool(true),
 			},
 			exp: &apiextensionsv1.JSONSchemaProps{
-				XPreserveUnknownFields: &trueBool,
+				XPreserveUnknownFields: pointer.Bool(true),
 			},
 		},
 		{
@@ -63,7 +63,7 @@ func TestAddPreserveUnknownFields(t *testing.T) {
 				Type: "object",
 			},
 			exp: &apiextensionsv1.JSONSchemaProps{
-				XPreserveUnknownFields: &trueBool,
+				XPreserveUnknownFields: pointer.Bool(true),
 				Type:                   "object",
 			},
 		},
@@ -76,7 +76,7 @@ func TestAddPreserveUnknownFields(t *testing.T) {
 				Type: "array",
 				Items: &apiextensionsv1.JSONSchemaPropsOrArray{
 					Schema: &apiextensionsv1.JSONSchemaProps{
-						XPreserveUnknownFields: &trueBool,
+						XPreserveUnknownFields: pointer.Bool(true),
 					},
 				},
 			},
@@ -91,7 +91,7 @@ func TestAddPreserveUnknownFields(t *testing.T) {
 				Type: "array",
 				Items: &apiextensionsv1.JSONSchemaPropsOrArray{
 					Schema: &apiextensionsv1.JSONSchemaProps{
-						XPreserveUnknownFields: &trueBool,
+						XPreserveUnknownFields: pointer.Bool(true),
 					},
 				},
 			},
@@ -104,10 +104,10 @@ func TestAddPreserveUnknownFields(t *testing.T) {
 				},
 			},
 			exp: &apiextensionsv1.JSONSchemaProps{
-				XPreserveUnknownFields: &trueBool,
+				XPreserveUnknownFields: pointer.Bool(true),
 				Properties: map[string]apiextensionsv1.JSONSchemaProps{
 					"foo": {
-						XPreserveUnknownFields: &trueBool,
+						XPreserveUnknownFields: pointer.Bool(true),
 					},
 				},
 			},
@@ -126,11 +126,11 @@ func TestAddPreserveUnknownFields(t *testing.T) {
 				},
 			},
 			exp: &apiextensionsv1.JSONSchemaProps{
-				XPreserveUnknownFields: &trueBool,
+				XPreserveUnknownFields: pointer.Bool(true),
 				Items: &apiextensionsv1.JSONSchemaPropsOrArray{
 					Schema: &apiextensionsv1.JSONSchemaProps{
 						Type:                   "object",
-						XPreserveUnknownFields: &trueBool,
+						XPreserveUnknownFields: pointer.Bool(true),
 						Properties: map[string]apiextensionsv1.JSONSchemaProps{
 							"key":          {Type: "string"},
 							"allowedRegex": {Type: "string"},
@@ -156,11 +156,11 @@ func TestAddPreserveUnknownFields(t *testing.T) {
 			},
 			exp: &apiextensionsv1.JSONSchemaProps{
 				Type:                   "object",
-				XPreserveUnknownFields: &trueBool,
+				XPreserveUnknownFields: pointer.Bool(true),
 				Properties: map[string]apiextensionsv1.JSONSchemaProps{
 					"foo": {
 						Type:                   "object",
-						XPreserveUnknownFields: &trueBool,
+						XPreserveUnknownFields: pointer.Bool(true),
 						Properties: map[string]apiextensionsv1.JSONSchemaProps{
 							"bar": {
 								Type: "string",
@@ -192,15 +192,15 @@ func TestAddPreserveUnknownFields(t *testing.T) {
 			},
 			exp: &apiextensionsv1.JSONSchemaProps{
 				Type:                   "object",
-				XPreserveUnknownFields: &trueBool,
+				XPreserveUnknownFields: pointer.Bool(true),
 				Properties: map[string]apiextensionsv1.JSONSchemaProps{
 					"foo": {
 						Type:                   "object",
-						XPreserveUnknownFields: &trueBool,
+						XPreserveUnknownFields: pointer.Bool(true),
 						Properties: map[string]apiextensionsv1.JSONSchemaProps{
 							"bar": {
 								Type:                   "object",
-								XPreserveUnknownFields: &trueBool,
+								XPreserveUnknownFields: pointer.Bool(true),
 								Properties: map[string]apiextensionsv1.JSONSchemaProps{
 									"burrito": {
 										Type: "string",
@@ -226,10 +226,10 @@ func TestAddPreserveUnknownFields(t *testing.T) {
 				},
 			},
 			exp: &apiextensionsv1.JSONSchemaProps{
-				XPreserveUnknownFields: &trueBool,
+				XPreserveUnknownFields: pointer.Bool(true),
 				Items: &apiextensionsv1.JSONSchemaPropsOrArray{
 					Schema: &apiextensionsv1.JSONSchemaProps{
-						XPreserveUnknownFields: &trueBool,
+						XPreserveUnknownFields: pointer.Bool(true),
 						Items: &apiextensionsv1.JSONSchemaPropsOrArray{
 							Schema: &apiextensionsv1.JSONSchemaProps{
 								Type: "string",
@@ -280,10 +280,10 @@ func TestAddPreserveUnknownFields(t *testing.T) {
 				},
 			},
 			exp: &apiextensionsv1.JSONSchemaProps{
-				XPreserveUnknownFields: &trueBool,
+				XPreserveUnknownFields: pointer.Bool(true),
 				AdditionalProperties: &apiextensionsv1.JSONSchemaPropsOrBool{
 					Schema: &apiextensionsv1.JSONSchemaProps{
-						XPreserveUnknownFields: &trueBool,
+						XPreserveUnknownFields: pointer.Bool(true),
 						AdditionalProperties: &apiextensionsv1.JSONSchemaPropsOrBool{
 							Allows: false,
 						},

--- a/constraint/pkg/types/validation.go
+++ b/constraint/pkg/types/validation.go
@@ -96,7 +96,6 @@ func (r *Responses) HandledCount() int {
 
 	c := 0
 	for _, h := range r.Handled {
-		// TODO(now): Unit tests for Responses.
 		if h {
 			c++
 		}

--- a/constraint/pkg/types/validation.go
+++ b/constraint/pkg/types/validation.go
@@ -93,12 +93,15 @@ func (r *Responses) HandledCount() int {
 	if r == nil {
 		return 0
 	}
+
 	c := 0
 	for _, h := range r.Handled {
+		// TODO(now): Unit tests for Responses.
 		if h {
 			c++
 		}
 	}
+
 	return c
 }
 

--- a/constraint/pkg/types/validation_test.go
+++ b/constraint/pkg/types/validation_test.go
@@ -1,0 +1,62 @@
+package types
+
+import "testing"
+
+func TestResponses_HandledCount(t *testing.T) {
+	testCases := []struct {
+		name      string
+		responses Responses
+		want      int
+	}{
+		{
+			name:      "empty responses",
+			responses: Responses{},
+			want:      0,
+		},
+		{
+			name: "one handled",
+			responses: Responses{
+				Handled: map[string]bool{"a": true},
+			},
+			want: 1,
+		},
+		{
+			name: "two handled",
+			responses: Responses{
+				Handled: map[string]bool{"a": true, "b": true},
+			},
+			want: 2,
+		},
+		{
+			name: "one handled and not handled",
+			responses: Responses{
+				Handled: map[string]bool{"a": true, "b": false},
+			},
+			want: 1,
+		},
+		{
+			name: "one not handled and one handled",
+			responses: Responses{
+				Handled: map[string]bool{"a": false, "b": true},
+			},
+			want: 1,
+		},
+		{
+			name: "none handled",
+			responses: Responses{
+				Handled: map[string]bool{"a": false, "b": false},
+			},
+			want: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.responses.HandledCount()
+
+			if got != tc.want {
+				t.Fatalf("got HandledCount() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Move pkg/client to use go113 errors conventions.

In general, move to using constant base errors and wrap them with fmt.Errorf. Also make tests check that the expected error is returned.

In many cases I've extended tests to make them more flexible to accommodate this. I've made the tests more flexible, but haven't added examples of using that flexibility (for example, a client working with multiple targets). I intend to do so in a separate PR.

Fix a few concurrency bugs - the RW mutex wasn't properly guarding writes vs. reads for constraints. Also consider two Constraints with empty Specs to be "Semantically equal" as it is valid for Constraints to have empty specs.