### PR TITLE
Provide IsUnrecognizedConstraintError

### DIFF
--- a/constraint/pkg/client/errors.go
+++ b/constraint/pkg/client/errors.go
@@ -38,6 +38,11 @@ func (e *UnrecognizedConstraintError) Error() string {
 	return fmt.Sprintf("Constraint kind %s is not recognized", e.s)
 }
 
+func IsUnrecognizedConstraintError(e error) bool {
+	_, ok := e.(*UnrecognizedConstraintError)
+	return ok
+}
+
 func NewUnrecognizedConstraintError(text string) error {
 	return &UnrecognizedConstraintError{text}
 }


### PR DESCRIPTION
For decoupling frameworks and gatekeeper error handling
(which allows using go113 error conventinos in tests), I need to remove
the dependence of gatekeeper on error types defined in frameworks so
these may be changed safely to raw errors (where reasonable to do so).

As an intermediate, I'm adding this function so that gatekeeper can
continue to compile, and the implementation of this method may be
switched out in frameworks.

Signed-off-by: Will Beason <willbeason@google.com>