### PR TITLE
Add ToMatcher to TargetHandler

### DIFF
--- a/constraint/pkg/client/client_test.go
+++ b/constraint/pkg/client/client_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/client/drivers/local"
+	"github.com/open-policy-agent/frameworks/constraint/pkg/core/constraints"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/core/templates"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/types"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
@@ -27,6 +28,10 @@ type badHandler struct {
 	Errors      bool
 	HasLib      bool
 	HandlesData bool
+}
+
+func (h *badHandler) ToMatcher(_ *unstructured.Unstructured) (constraints.Matcher, error) {
+	return nil, errors.New("unimplemented")
 }
 
 func (h *badHandler) GetName() string {

--- a/constraint/pkg/client/targethandler.go
+++ b/constraint/pkg/client/targethandler.go
@@ -3,6 +3,7 @@ package client
 import (
 	"text/template"
 
+	"github.com/open-policy-agent/frameworks/constraint/pkg/core/constraints"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/types"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -91,6 +92,12 @@ type TargetHandler interface {
 	// This allows for semantic validation beyond OpenAPI validation given by the
 	// spec from MatchSchema().
 	ValidateConstraint(constraint *unstructured.Unstructured) error
+
+	// ToMatcher converts a Constraint to its corresponding Matcher.
+	// CURRENTLY UNIMPLEMENTED.
+	// Allows caching Constraint-specific logic for matching objects under
+	// review.
+	ToMatcher(constraint *unstructured.Unstructured) (constraints.Matcher, error)
 }
 
 type MatchSchemaProvider interface {

--- a/constraint/pkg/client/test_handler.go
+++ b/constraint/pkg/client/test_handler.go
@@ -2,8 +2,10 @@ package client
 
 import (
 	"encoding/json"
+	"errors"
 	"text/template"
 
+	"github.com/open-policy-agent/frameworks/constraint/pkg/core/constraints"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/types"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -12,6 +14,10 @@ import (
 var _ TargetHandler = &handler{}
 
 type handler struct{}
+
+func (h *handler) ToMatcher(_ *unstructured.Unstructured) (constraints.Matcher, error) {
+	return nil, errors.New("unimplemented")
+}
 
 func (h *handler) GetName() string {
 	return "test.target"

--- a/constraint/pkg/core/constraints/constraints.go
+++ b/constraint/pkg/core/constraints/constraints.go
@@ -24,7 +24,7 @@ func SemanticEqual(c1 *unstructured.Unstructured, c2 *unstructured.Unstructured)
 	return reflect.DeepEqual(s1, s2)
 }
 
-// Matcher matches objects
+// Matcher matches objects.
 type Matcher interface {
 	Match(obj interface{}) (bool, error)
 }

--- a/constraint/pkg/core/constraints/constraints.go
+++ b/constraint/pkg/core/constraints/constraints.go
@@ -24,7 +24,10 @@ func SemanticEqual(c1 *unstructured.Unstructured, c2 *unstructured.Unstructured)
 	return reflect.DeepEqual(s1, s2)
 }
 
-// Matcher matches objects.
+// Matcher matches object review requests.
 type Matcher interface {
-	Match(obj interface{}) (bool, error)
+	// Match returns true if the Matcher's Constraint should run against the
+	// passed review object.
+	// Note that this is the review object returned by HandleReview.
+	Match(review interface{}) (bool, error)
 }

--- a/constraint/pkg/core/constraints/constraints.go
+++ b/constraint/pkg/core/constraints/constraints.go
@@ -15,7 +15,16 @@ func SemanticEqual(c1 *unstructured.Unstructured, c2 *unstructured.Unstructured)
 		return c1 == c2
 	}
 
+	if c1.Object == nil || c2.Object == nil {
+		return (c1.Object == nil) == (c2.Object == nil)
+	}
+
 	s1 := c1.Object["spec"]
 	s2 := c2.Object["spec"]
 	return reflect.DeepEqual(s1, s2)
+}
+
+// Matcher matches objects
+type Matcher interface {
+	Match(obj interface{}) (bool, error)
 }

--- a/constraint/pkg/core/constraints/constraints_test.go
+++ b/constraint/pkg/core/constraints/constraints_test.go
@@ -38,6 +38,26 @@ func TestSemanticEqual(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "nil objects",
+			c1: &unstructured.Unstructured{
+				Object: nil,
+			},
+			c2: &unstructured.Unstructured{
+				Object: nil,
+			},
+			want: true,
+		},
+		{
+			name: "nil and non-nil Object",
+			c1: &unstructured.Unstructured{
+				Object: map[string]interface{}{},
+			},
+			c2: &unstructured.Unstructured{
+				Object: nil,
+			},
+			want: false,
+		},
+		{
 			name: "one empty Constraint",
 			c1: &unstructured.Unstructured{
 				Object: map[string]interface{}{


### PR DESCRIPTION
The idea here is that we can cache the golang match criteria for each
Constraint, rather than parsing it out each time. This PR does not actually implement the behavior; it just defines the interface so that we can start using it in Gatekeeper.

Also fix bug in SemanticEqual where one Constraint has Object defined
and the other does not.

Signed-off-by: Will Beason <willbeason@google.com>