### PR TITLE
Add support for print built-in

### DIFF
--- a/constraint/pkg/client/drivers/local/args.go
+++ b/constraint/pkg/client/drivers/local/args.go
@@ -5,6 +5,7 @@ import (
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/storage/inmem"
+	"github.com/open-policy-agent/opa/topdown/print"
 	opatypes "github.com/open-policy-agent/opa/types"
 )
 
@@ -42,6 +43,18 @@ func Defaults() Arg {
 func Tracing(enabled bool) Arg {
 	return func(d *driver) {
 		d.traceEnabled = enabled
+	}
+}
+
+func PrintEnabled(enabled bool) Arg {
+	return func(d *driver) {
+		d.printEnabled = enabled
+	}
+}
+
+func PrintHook(hook print.Hook) Arg {
+	return func(d *driver) {
+		d.printHook = hook
 	}
 }
 


### PR DESCRIPTION
While playing around with the Gator CLI today I noticed
that I couldn't use the new print built-in from OPA in that
context. This function is really useful to quickly be able to
debug values of rules and variables, and would be a nice
addition to the Gator CLI (and possibly to the Gatekeeper
server too, but others can decide that). This PR adds options
to the local driver for enabling print and for providing a
printHook that decides where the output of print calls should
go. Will submit another PR for support in Gator if/when this
is merged.

Signed-off-by: Anders Eknert <anders@eknert.com>