### PR TITLE
fix: Content-Type header for external_data request

### DIFF
--- a/constraint/pkg/client/drivers/local/local.go
+++ b/constraint/pkg/client/drivers/local/local.go
@@ -113,6 +113,7 @@ func (d *Driver) Init() error {
 				if err != nil {
 					return externaldata.HandleError(http.StatusInternalServerError, err)
 				}
+				req.Header.Set("Content-Type", "application/json")
 
 				ctx, cancel := context.WithDeadline(bctx.Context, time.Now().Add(time.Duration(provider.Spec.Timeout)*time.Second))
 				defer cancel()


### PR DESCRIPTION
Fixes https://github.com/open-policy-agent/frameworks/issues/191

## Summary
* Set `Content-Type` header for `external_data` request

cc: @sozercan 

Signed-off-by: Joel Kamp <joel.kamp@invitae.com>