### PR TITLE
chore: bump golangci-lint version to 1.45.2

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,7 +13,7 @@ jobs:
       uses: golangci/golangci-lint-action@v2
       with:
         # version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-        version: v1.42.1
+        version: v1.45.2
         working-directory: constraint
 
   test:


### PR DESCRIPTION
Signed-off-by: Sertac Ozercan <sozercan@gmail.com>