### PR TITLE
perf: Don't cache Constraint status

### DIFF
--- a/constraint/pkg/client/client.go
+++ b/constraint/pkg/client/client.go
@@ -18,6 +18,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
+const statusField = "status"
+
 // Client tracks ConstraintTemplates and Constraints for a set of Targets.
 // Allows validating reviews against Constraints.
 //

--- a/constraint/pkg/client/client_test.go
+++ b/constraint/pkg/client/client_test.go
@@ -998,8 +998,8 @@ func TestClient_AddConstraint(t *testing.T) {
 				t.Error("cached Constraint does not equal stored constraint")
 			}
 
-			if tc.constraint.Object["status"] != nil {
-				t.Error("cached Constraint includes status")
+			if cached.Object["status"] != nil {
+				t.Errorf("cached Constraint includes status: %#v", cached.Object["status"])
 			}
 
 			r2, err := c.RemoveConstraint(ctx, tc.constraint)

--- a/constraint/pkg/client/client_test.go
+++ b/constraint/pkg/client/client_test.go
@@ -932,6 +932,17 @@ func TestClient_AddConstraint(t *testing.T) {
 			},
 			wantGetConstraintError: client.ErrMissingConstraint,
 		},
+		{
+			name:     "remove status field",
+			template: clienttest.TemplateDeny(),
+			constraint: cts.MakeConstraint(t, clienttest.KindDeny, "constraint",
+				cts.Set("some status", "status")),
+			wantAddConstraintError: nil,
+			wantGetConstraintError: nil,
+			wantHandled: map[string]bool{
+				handlertest.TargetName: true,
+			},
+		},
 	}
 
 	for _, tc := range tcs {
@@ -984,7 +995,11 @@ func TestClient_AddConstraint(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.constraint.Object["spec"], cached.Object["spec"]); diff != "" {
-				t.Error("cached constraint does not equal stored constraint")
+				t.Error("cached Constraint does not equal stored constraint")
+			}
+
+			if tc.constraint.Object["status"] != nil {
+				t.Error("cached Constraint includes status")
 			}
 
 			r2, err := c.RemoveConstraint(ctx, tc.constraint)

--- a/constraint/pkg/client/drivers/local/driver.go
+++ b/constraint/pkg/client/drivers/local/driver.go
@@ -103,6 +103,7 @@ func (d *Driver) RemoveTemplate(ctx context.Context, templ *templates.Constraint
 // AddConstraint adds Constraint to Rego storage. Future calls to Query will
 // be evaluated against Constraint if the Constraint's key is passed.
 func (d *Driver) AddConstraint(ctx context.Context, constraint *unstructured.Unstructured) error {
+	// Note that this discards "status" as we're only copy spec.parameters.
 	params, _, err := unstructured.NestedFieldNoCopy(constraint.Object, "spec", "parameters")
 	if err != nil {
 		return fmt.Errorf("%w: %v", constraints.ErrInvalidConstraint, err)

--- a/constraint/pkg/client/drivers/local/driver.go
+++ b/constraint/pkg/client/drivers/local/driver.go
@@ -103,7 +103,7 @@ func (d *Driver) RemoveTemplate(ctx context.Context, templ *templates.Constraint
 // AddConstraint adds Constraint to Rego storage. Future calls to Query will
 // be evaluated against Constraint if the Constraint's key is passed.
 func (d *Driver) AddConstraint(ctx context.Context, constraint *unstructured.Unstructured) error {
-	// Note that this discards "status" as we're only copy spec.parameters.
+	// Note that this discards "status" as we only copy spec.parameters.
 	params, _, err := unstructured.NestedFieldNoCopy(constraint.Object, "spec", "parameters")
 	if err != nil {
 		return fmt.Errorf("%w: %v", constraints.ErrInvalidConstraint, err)

--- a/constraint/pkg/client/template_client.go
+++ b/constraint/pkg/client/template_client.go
@@ -81,8 +81,11 @@ func (e *templateClient) AddConstraint(constraint *unstructured.Unstructured) (b
 		return false, err
 	}
 
+	cpy := constraint.DeepCopy()
+	delete(cpy.Object, statusField)
+
 	e.constraints[constraint.GetName()] = &constraintClient{
-		constraint:        constraint.DeepCopy(),
+		constraint:        cpy,
 		matchers:          matchers,
 		enforcementAction: enforcementAction,
 	}


### PR DESCRIPTION
Constraint status is ephemeral and callers should not be relying on our
cached version of the status field. Also, status can be very large, and
caching it wastes space.

Note that the Driver already drops `status` as it only preserves `spec.parameters`.

Signed-off-by: Will Beason <willbeason@google.com>

Fixes #209 