### PR TITLE
chore: increase gatekeeper test timeout

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -19,7 +19,7 @@ jobs:
   test:
     name: "Unit test"
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Set up Go 1.17
         uses: actions/setup-go@v2

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,7 +13,7 @@ jobs:
       uses: golangci/golangci-lint-action@v2
       with:
         # version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-        version: v1.42.1
+        version: v1.45.2
         working-directory: constraint
 
   test:


### PR DESCRIPTION
we added race conditions for unit tests, looks like we are hitting timeout

Signed-off-by: Sertac Ozercan <sozercan@gmail.com>