### PR TITLE
Add Constraint schema validation error

### DIFF
--- a/constraint/pkg/apis/constraints/apis.go
+++ b/constraint/pkg/apis/constraints/apis.go
@@ -19,7 +19,14 @@ const (
 	EnforcementActionDeny = "deny"
 )
 
-var ErrInvalidConstraint = errors.New("invalid Constraint")
+var (
+	// ErrInvalidConstraint is a generic error that a Constraint is invalid for
+	// some reason.
+	ErrInvalidConstraint = errors.New("invalid Constraint")
+
+	// ErrSchema is a specific error that a Constraint failed schema validation.
+	ErrSchema = errors.New("schema validation failed")
+)
 
 // GetEnforcementAction returns a Constraint's enforcementAction, which indicates
 // what should be done if a review violates a Constraint, or the Constraint fails

--- a/constraint/pkg/client/client_test.go
+++ b/constraint/pkg/client/client_test.go
@@ -919,7 +919,7 @@ func TestClient_AddConstraint(t *testing.T) {
 			template: clienttest.TemplateDeny(),
 			constraint: cts.MakeConstraint(t, clienttest.KindDeny, "constraint",
 				cts.Set(int64(3), "spec", "enforcementAction")),
-			wantAddConstraintError: constraints.ErrInvalidConstraint,
+			wantAddConstraintError: constraints.ErrSchema,
 			wantGetConstraintError: client.ErrMissingConstraint,
 		},
 		{


### PR DESCRIPTION
This is so that "gator verify" tests may check the schema of
Constraints. We need an error specific to schema validation so users can
explicitly test for this case.

Required for https://github.com/open-policy-agent/gatekeeper/issues/1989