### PR TITLE
perf: Remove `with` statement to avoid deepcopying data.inventory

### DIFF
--- a/constraint/pkg/client/drivers/local/driver_unit_test.go
+++ b/constraint/pkg/client/drivers/local/driver_unit_test.go
@@ -768,7 +768,7 @@ func TestDriver_RemoveData_StorageErrors(t *testing.T) {
 			name: "commit error",
 			storage: &commitErrorStorage{
 				fakeStorage: fakeStorage{values: map[string]interface{}{
-					"/external/foo": "bar",
+					"/inventory/foo": "bar",
 				}},
 			},
 			wantErr: clienterrors.ErrTransaction,

--- a/constraint/pkg/client/drivers/local/rego.go
+++ b/constraint/pkg/client/drivers/local/rego.go
@@ -34,8 +34,7 @@ violation[response] {
   }
 
   # Run the Template with Constraint.
-  inventory[inv]
-  data.template.violation[r] with input as inp with data.inventory as inv
+  data.template.violation[r] with input as inp
 
   # Construct the response, defaulting "details" to empty object if it is not
   # specified.
@@ -44,13 +43,6 @@ violation[response] {
     "details": object.get(r, "details", {}),
     "msg": r.msg,
   }
-}
-
-inventory[inv] {
-	inv = data.external
-}
-inventory[{}] {
-	not data.external
 }
 `
 )

--- a/constraint/pkg/client/drivers/local/storages.go
+++ b/constraint/pkg/client/drivers/local/storages.go
@@ -103,7 +103,7 @@ func (d *storages) getStorage(ctx context.Context, target string) (storage.Store
 }
 
 func inventoryPath(path []string) storage.Path {
-	return append([]string{"external"}, path...)
+	return append([]string{"inventory"}, path...)
 }
 
 func addData(ctx context.Context, store storage.Store, path storage.Path, data interface{}) error {


### PR DESCRIPTION
This is a possible fix for https://github.com/open-policy-agent/gatekeeper/issues/2283

Digging through the OPA code, the `with` statement triggers a deepcopy of the referenced data. With the new execution model implemented for performance improvements, this deepcopy would be run multiple times, which could mean significant CPU overhead and unnecessary memory usage.

Not using the `with` key would make it harder to mask out only resources in specific namespaces if we ever create namespace-scoped constraint templates, but should not hurt near-term functionality.

It may be we will need an alternative method for accessing the data cache if we need to mask visibility in the future.

Signed-off-by: Max Smythe <smythe@google.com>