### PR TITLE
rework tracedump msg

### DIFF
--- a/constraint/pkg/client/e2e_test.go
+++ b/constraint/pkg/client/e2e_test.go
@@ -758,22 +758,22 @@ func TestE2E_Tracing(t *testing.T) {
 			td := rsps.TraceDump()
 			if tt.tracingEnabled {
 				if tt.deny {
-					if !strings.Contains(td, "Trace:") || strings.Contains(td, "Trace: TRACING DISABLED") {
+					if !strings.Contains(td, "Trace:") || strings.Contains(td, types.TracingDisabledHeader) {
 						t.Fatalf("did not find a trace when we were expecting to see one: %s", td)
 					}
 				} else {
-					if strings.Contains(td, "Trace: TRACING DISABLED") {
+					if strings.Contains(td, types.TracingDisabledHeader) {
 						t.Fatalf("tracing is not disabled, we just didn't see a violation: %s", td)
 					}
 				}
 			} else {
 				if tt.deny {
-					if !strings.Contains(td, "Trace: TRACING DISABLED") {
+					if !strings.Contains(td, types.TracingDisabledHeader) {
 						t.Fatalf("tracing is disabled, there shouldn't be a trace: %s", td)
 					}
 				} else {
-					if strings.Contains(td, "Trace: TRACING DISABLED") {
-						t.Fatalf("tracing is disabled, but there were no violations so \"Trace: TRACING DISABLED:\" shouldn't be present: %s", td)
+					if strings.Contains(td, types.TracingDisabledHeader) {
+						t.Fatalf("tracing is disabled, but there were no violations so \"%s\" shouldn't be present: %s", types.TracingDisabledHeader, td)
 					}
 				}
 			}
@@ -781,7 +781,7 @@ func TestE2E_Tracing(t *testing.T) {
 	}
 }
 
-// TestE2E_Tracing_Ignored tests that non evaluations don't have a misleading
+// TestE2E_Tracing_Unmatched tests that non evaluations don't have a misleading
 // message: \"Trace: TRACING DISABLED\" trace on a TraceDump().
 // A non evaluation can occur when a review doesn't match the constraint's match
 // criteria.
@@ -827,8 +827,8 @@ func TestE2E_Tracing_Unmatched(t *testing.T) {
 			}
 
 			td := rsps.TraceDump()
-			if strings.Contains(td, "Trace: TRACING DISABLED") {
-				t.Fatalf("\"Trace: TRACING DISABLED:\" shouldn't be present: %s", td)
+			if strings.Contains(td, types.TracingDisabledHeader) {
+				t.Fatalf("\"%s\" shouldn't be present: %s", types.TracingDisabledHeader, td)
 			}
 		})
 	}

--- a/constraint/pkg/types/validation.go
+++ b/constraint/pkg/types/validation.go
@@ -65,7 +65,15 @@ func (r *Response) TraceDump() string {
 	b := &strings.Builder{}
 	_, _ = fmt.Fprintf(b, "Target: %s\n", r.Target)
 	if r.Trace == nil {
-		_, _ = fmt.Fprintf(b, "Trace: TRACING DISABLED\n\n")
+		if r.Results != nil {
+			// only say "Trace: TRACING DISABLED" if there are results
+			// otherwise, we risk to confuse consumers who see the msg
+			// and think that evaluation did not happen.
+
+			// Note that if there were NO violating results AND the trace
+			// was turned on, then r.Trace != nil.
+			_, _ = fmt.Fprintf(b, "Trace: TRACING DISABLED\n\n")
+		}
 	} else {
 		_, _ = fmt.Fprintf(b, "Trace:\n%s\n\n", *r.Trace)
 	}

--- a/constraint/pkg/types/validation.go
+++ b/constraint/pkg/types/validation.go
@@ -9,6 +9,10 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
+const (
+	TracingDisabledHeader = "Trace: TRACING DISABLED"
+)
+
 type Result struct {
 	// Target is the target this violation is for.
 	Target string `json:"target"`
@@ -72,7 +76,8 @@ func (r *Response) TraceDump() string {
 
 			// Note that if there were NO violating results AND the trace
 			// was turned on, then r.Trace != nil.
-			_, _ = fmt.Fprintf(b, "Trace: TRACING DISABLED\n\n")
+			b.WriteString(TracingDisabledHeader)
+			b.WriteString("\n\n")
 		}
 	} else {
 		_, _ = fmt.Fprintf(b, "Trace:\n%s\n\n", *r.Trace)


### PR DESCRIPTION
If a review doesn't match a constraint's match spec AND tracing is enabled, then we print `TRACE: TRACING DISABLED`. This can confuse consumers because they specifically turn on tracing. We should only print this message if there are results and the trace is nil. See non test changes for in code comments too.