### PR TITLE
fix: default params for open api

### DIFF
--- a/constraint/pkg/client/client.go
+++ b/constraint/pkg/client/client.go
@@ -358,18 +358,18 @@ func (c *Client) AddConstraint(ctx context.Context, constraint *unstructured.Uns
 		return resp, clienterrors.ErrNoDriver
 	}
 
-	constraintWDefaults, err := c.withDefaultParams(constraint, template)
+	constraintWithDefaults, err := c.withDefaultParams(constraint, template)
 	if err != nil {
 		return resp, err
 	}
 
-	changed, err := cached.AddConstraint(constraintWDefaults)
+	changed, err := cached.AddConstraint(constraintWithDefaults)
 	if err != nil {
 		return resp, err
 	}
 
 	if changed {
-		err = driver.AddConstraint(ctx, constraintWDefaults)
+		err = driver.AddConstraint(ctx, constraintWithDefaults)
 		if err != nil {
 			return resp, err
 		}
@@ -387,7 +387,7 @@ func (c *Client) AddConstraint(ctx context.Context, constraint *unstructured.Uns
 //
 //	Returns a copy of the constraint with the defaults or an error in processing the schema and constraint.
 func (c *Client) withDefaultParams(constraint *unstructured.Unstructured, templ *templates.ConstraintTemplate) (*unstructured.Unstructured, error) {
-	if templ.Spec.CRD.Spec.Validation == nil || templ.Spec.CRD.Spec.Validation.LegacySchema != nil {
+	if templ.Spec.CRD.Spec.Validation == nil || templ.Spec.CRD.Spec.Validation.OpenAPIV3Schema == nil {
 		return constraint, nil
 	}
 

--- a/constraint/pkg/client/client.go
+++ b/constraint/pkg/client/client.go
@@ -323,8 +323,8 @@ func (c *Client) GetTemplate(templ *templates.ConstraintTemplate) (*templates.Co
 	return template.getTemplate(), nil
 }
 
-// getTemplateEntry returns the template entry for a given constraint.
-func (c *Client) getTemplateForKind(kind string) *templateClient {
+// getTemplateClientForKind returns the template entry for a given constraint.
+func (c *Client) getTemplateClientForKind(kind string) *templateClient {
 	name := strings.ToLower(kind)
 
 	return c.templates[name]
@@ -345,7 +345,7 @@ func (c *Client) AddConstraint(ctx context.Context, constraint *unstructured.Uns
 	}
 
 	kind := constraint.GetKind()
-	cached := c.getTemplateForKind(kind)
+	cached := c.getTemplateClientForKind(kind)
 	if cached == nil {
 		templateName := strings.ToLower(kind)
 		return resp, templateNotFound(templateName)
@@ -358,7 +358,7 @@ func (c *Client) AddConstraint(ctx context.Context, constraint *unstructured.Uns
 		return resp, clienterrors.ErrNoDriver
 	}
 
-	constraintWithDefaults, err := c.withDefaultParams(constraint, template)
+	constraintWithDefaults, err := cached.ApplyDefaultParams(constraint)
 	if err != nil {
 		return resp, err
 	}
@@ -382,51 +382,6 @@ func (c *Client) AddConstraint(ctx context.Context, constraint *unstructured.Uns
 	return resp, nil
 }
 
-// withDefaultParams injects any default values defined in the OpenAPIV3Schema
-// to the constraint spec only if a parameter is not already defined in the constraint.
-//
-//	Returns a copy of the constraint with the defaults or an error in processing the schema and constraint.
-func (c *Client) withDefaultParams(constraint *unstructured.Unstructured, templ *templates.ConstraintTemplate) (*unstructured.Unstructured, error) {
-	if templ.Spec.CRD.Spec.Validation == nil || templ.Spec.CRD.Spec.Validation.OpenAPIV3Schema == nil {
-		return constraint, nil
-	}
-
-	cpy := constraint.DeepCopy()
-	defaults := map[string]*apiextensions.JSON{}
-	schema := templ.Spec.CRD.Spec.Validation.OpenAPIV3Schema
-
-	for paramName := range schema.Properties {
-		paramProps := schema.Properties[paramName]
-
-		if paramProps.Default != nil {
-			defaults[paramName] = paramProps.Default
-		}
-	}
-
-	_, _, err := unstructured.NestedFieldNoCopy(cpy.Object, "spec", "parameters")
-	if err != nil {
-		return nil, fmt.Errorf("%w: %v", apiconstraints.ErrInvalidConstraint, err)
-	}
-
-	for paramName, defaultParam := range defaults {
-		// only look to default parameters that are not found
-		_, found, err := unstructured.NestedFieldNoCopy(cpy.Object, "spec", "parameters", paramName)
-		if err != nil {
-			return nil, fmt.Errorf("could not find parameter %s in CRD %w: %v", paramName, apiconstraints.ErrInvalidConstraint, err)
-		}
-
-		// by definition, if we looked up a paramName, it was a parameter
-		// that had a Default defined in the schema so we are right to default it.
-		if !found {
-			if err := unstructured.SetNestedField(cpy.Object, *defaultParam, "spec", "parameters", paramName); err != nil {
-				return nil, err
-			}
-		}
-	}
-
-	return cpy, nil
-}
-
 // RemoveConstraint removes a constraint from OPA. On error, the responses
 // return value will still be populated so that partial results can be analyzed.
 func (c *Client) RemoveConstraint(ctx context.Context, constraint *unstructured.Unstructured) (*types.Responses, error) {
@@ -442,7 +397,7 @@ func (c *Client) RemoveConstraint(ctx context.Context, constraint *unstructured.
 
 	kind := constraint.GetKind()
 
-	cached := c.getTemplateForKind(kind)
+	cached := c.getTemplateClientForKind(kind)
 	if cached == nil {
 		// The Template has been deleted, so nothing to do and no reason to return
 		// error.
@@ -483,7 +438,7 @@ func (c *Client) GetConstraint(constraint *unstructured.Unstructured) (*unstruct
 	defer c.mtx.RUnlock()
 
 	kind := constraint.GetKind()
-	template := c.getTemplateForKind(kind)
+	template := c.getTemplateClientForKind(kind)
 	if template == nil {
 		templateName := strings.ToLower(kind)
 		return nil, templateNotFound(templateName)
@@ -517,7 +472,7 @@ func (c *Client) validateConstraint(constraint *unstructured.Unstructured) error
 	}
 
 	kind := constraint.GetKind()
-	template := c.getTemplateForKind(kind)
+	template := c.getTemplateClientForKind(kind)
 	if template == nil {
 		templateName := strings.ToLower(kind)
 		return templateNotFound(templateName)

--- a/constraint/pkg/client/client_test.go
+++ b/constraint/pkg/client/client_test.go
@@ -1078,12 +1078,6 @@ func TestClient_AddConstraint_withDefaultParams(t *testing.T) {
 		// default is fake.
 		driver drivers.Driver
 	}{
-		// this no op test case is tested implicitly in all
-		// AddConstraint calls outside of this test
-		{
-			name:   "no defaults",
-			driver: regoDriver,
-		},
 		{
 			name: "defaults for one",
 			validationSpec: &templates.Validation{
@@ -1144,9 +1138,6 @@ func TestClient_AddConstraint_withDefaultParams(t *testing.T) {
 			},
 			driver: regoDriver,
 		},
-		// this is the most interesting test as it shows:
-		// - two parameters defaulting
-		// - one parameter that is defined in the constraint AND does not default
 		{
 			name: "defaults for two, one mixed",
 			validationSpec: &templates.Validation{
@@ -1178,9 +1169,6 @@ func TestClient_AddConstraint_withDefaultParams(t *testing.T) {
 					},
 				},
 			},
-			// note that since the constraint is already creted when we modify it
-			// in place to simulate a constraint defining a fuzz parameter, we
-			// won't actually trigger a schema validation error.
 			constraintSpec: map[string]interface{}{
 				"parameters": map[string]interface{}{
 					"fuzz": "buzz",

--- a/constraint/pkg/client/client_test.go
+++ b/constraint/pkg/client/client_test.go
@@ -1277,18 +1277,11 @@ func TestClient_AddConstraint_withDefaultParams(t *testing.T) {
 				t.Fatalf("got GetConstraint() error = %v, want %v",
 					err, tc.wantGetConstraintError)
 			}
-
 			if tc.wantGetConstraintError != nil {
 				return
 			}
+
 			// we expect the constraints to be parametrized as per the open api v3 defaults
-
-			if tc.validationSpec != nil {
-				if diff := cmp.Diff(constraint.Object["spec"], cached.Object["spec"]); diff == "" {
-					t.Error("cached Constraint does equals stored constraint; it shouldn't")
-				}
-			}
-
 			if tc.wantSpec != nil {
 				if diff := cmp.Diff(tc.wantSpec, cached.Object["spec"]); diff != "" {
 					t.Error("cached Constraint does not equal wantConstraint constraint", diff)

--- a/constraint/pkg/client/client_test.go
+++ b/constraint/pkg/client/client_test.go
@@ -1053,7 +1053,7 @@ func TestClient_AddConstraint_withDefaultParams(t *testing.T) {
 
 	target := &handlertest.Handler{}
 	template := cts.New()
-	constraint := cts.MakeConstraintNoParams(t, "Fakes", "fakes")
+	constraint := cts.MakeConstraint(t, "Fakes", "fakes")
 
 	regoDriver, err := rego.New()
 	if err != nil {
@@ -1287,12 +1287,9 @@ func TestClient_AddConstraint_withDefaultParams(t *testing.T) {
 					t.Error("cached Constraint does not equal wantConstraint constraint", diff)
 				}
 			} else {
-				_, found, err := unstructured.NestedFieldNoCopy(cached.Object, "spec", "parameters")
+				_, _, err := unstructured.NestedFieldNoCopy(cached.Object, "spec", "parameters")
 				if err != nil {
 					t.Error(err)
-				}
-				if found {
-					t.Error("params should not be populated")
 				}
 			}
 		})

--- a/constraint/pkg/client/client_test.go
+++ b/constraint/pkg/client/client_test.go
@@ -1075,7 +1075,7 @@ func TestClient_AddConstraint_withDefaultParams(t *testing.T) {
 		wantGetConstraintError error
 
 		// driver is pulled out to test actual driver implementations.
-		// defulat is fake.
+		// default is fake.
 		driver drivers.Driver
 	}{
 		// this no op test case is tested implicitly in all
@@ -1225,9 +1225,9 @@ func TestClient_AddConstraint_withDefaultParams(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			tc := tc
-			// given a template and constraint for it
-			template := template.DeepCopy()
-			constraint := constraint.DeepCopy()
+			// given a baseTemplate and constraint for it
+			baseTemplate := template.DeepCopy()
+			baseConstraint := constraint.DeepCopy()
 
 			// handle tc defaults
 			if tc.wantHandled == nil {
@@ -1238,10 +1238,10 @@ func TestClient_AddConstraint_withDefaultParams(t *testing.T) {
 				tc.driver = d
 			}
 			if tc.validationSpec != nil {
-				template.Spec.CRD.Spec.Validation = tc.validationSpec
+				baseTemplate.Spec.CRD.Spec.Validation = tc.validationSpec
 			}
 			if tc.constraintSpec != nil {
-				constraint.Object["spec"] = tc.constraintSpec
+				baseConstraint.Object["spec"] = tc.constraintSpec
 			}
 
 			c, err := client.NewClient(client.Targets(target), client.Driver(tc.driver))
@@ -1250,15 +1250,15 @@ func TestClient_AddConstraint_withDefaultParams(t *testing.T) {
 			}
 
 			ctx := context.Background()
-			if template != nil {
-				_, err = c.AddTemplate(ctx, template)
+			if baseTemplate != nil {
+				_, err = c.AddTemplate(ctx, baseTemplate)
 				if err != nil {
 					t.Fatal(err)
 				}
 			}
 
 			// when we add the constraint
-			r, err := c.AddConstraint(ctx, constraint)
+			r, err := c.AddConstraint(ctx, baseConstraint)
 			if !errors.Is(err, tc.wantAddConstraintError) {
 				t.Fatalf("got AddConstraint() error = %v, want %v",
 					err, tc.wantAddConstraintError)
@@ -1272,7 +1272,7 @@ func TestClient_AddConstraint_withDefaultParams(t *testing.T) {
 				t.Error(diff)
 			}
 
-			cached, err := c.GetConstraint(constraint)
+			cached, err := c.GetConstraint(baseConstraint)
 			if !errors.Is(err, tc.wantGetConstraintError) {
 				t.Fatalf("got GetConstraint() error = %v, want %v",
 					err, tc.wantGetConstraintError)

--- a/constraint/pkg/client/clienttest/cts/constraints.go
+++ b/constraint/pkg/client/clienttest/cts/constraints.go
@@ -36,28 +36,6 @@ func MakeConstraint(t testing.TB, kind, name string, args ...ConstraintArg) *uns
 	return u
 }
 
-func MakeConstraintNoParams(t testing.TB, kind, name string, args ...ConstraintArg) *unstructured.Unstructured {
-	t.Helper()
-
-	u := &unstructured.Unstructured{Object: make(map[string]interface{})}
-
-	u.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   constraints.Group,
-		Version: "v1beta1",
-		Kind:    kind,
-	})
-	u.SetName(name)
-
-	for _, arg := range args {
-		err := arg(u)
-		if err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	return u
-}
-
 type ConstraintArg func(*unstructured.Unstructured) error
 
 // MatchNamespace modifies the Constraint to only match objects with the passed

--- a/constraint/pkg/client/clienttest/cts/constraints.go
+++ b/constraint/pkg/client/clienttest/cts/constraints.go
@@ -36,6 +36,28 @@ func MakeConstraint(t testing.TB, kind, name string, args ...ConstraintArg) *uns
 	return u
 }
 
+func MakeConstraintNoParams(t testing.TB, kind, name string, args ...ConstraintArg) *unstructured.Unstructured {
+	t.Helper()
+
+	u := &unstructured.Unstructured{Object: make(map[string]interface{})}
+
+	u.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   constraints.Group,
+		Version: "v1beta1",
+		Kind:    kind,
+	})
+	u.SetName(name)
+
+	for _, arg := range args {
+		err := arg(u)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	return u
+}
+
 type ConstraintArg func(*unstructured.Unstructured) error
 
 // MatchNamespace modifies the Constraint to only match objects with the passed

--- a/constraint/pkg/client/template_client.go
+++ b/constraint/pkg/client/template_client.go
@@ -66,35 +66,12 @@ func (e *templateClient) ValidateConstraint(constraint *unstructured.Unstructure
 // corresponding template.
 // Assumes ValidateConstraint() called is called so the constraint is a valid CRD.
 func (e *templateClient) ApplyDefaultParams(constraint *unstructured.Unstructured) (*unstructured.Unstructured, error) {
-	params, found, err := unstructured.NestedFieldNoCopy(constraint.Object, "spec", "parameters")
-	if err != nil {
-		return nil, err
-	}
-	if !found {
-		params = make(map[string]interface{})
-	}
-
-	// sequentially get the structural schema for the spec field
 	structural, err := schema.NewStructural(e.crd.Spec.Validation.OpenAPIV3Schema)
 	if err != nil {
 		return nil, err
 	}
-	specStructural, ok := structural.Properties["spec"]
-	if !ok {
-		return nil, fmt.Errorf("failed to fetch structural schema for spec")
-	}
 
-	// if the template CRD defines parameters to begin with, then we look to default any
-	// parameters that specified a default in their schema definition.
-	structuralParameters, ok := specStructural.Properties["parameters"]
-	if ok {
-		defaulting.Default(params, &structuralParameters)
-
-		if err := unstructured.SetNestedField(constraint.Object, params, "spec", "parameters"); err != nil {
-			return nil, err
-		}
-	}
-
+	defaulting.Default(constraint.Object, structural)
 	return constraint, nil
 }
 

--- a/constraint/pkg/client/template_client.go
+++ b/constraint/pkg/client/template_client.go
@@ -64,7 +64,7 @@ func (e *templateClient) ValidateConstraint(constraint *unstructured.Unstructure
 
 // ApplyDefaultParams will apply any default parameters defined in the CRD of the constraint's
 // corresponding template.
-// Assumes ValidateConstraint() called is called so the constraint is a valid CRD.
+// Assumes ValidateConstraint() is called so the constraint is a valid CRD.
 func (e *templateClient) ApplyDefaultParams(constraint *unstructured.Unstructured) (*unstructured.Unstructured, error) {
 	structural, err := schema.NewStructural(e.crd.Spec.Validation.OpenAPIV3Schema)
 	if err != nil {

--- a/constraint/pkg/client/template_client.go
+++ b/constraint/pkg/client/template_client.go
@@ -10,10 +10,9 @@ import (
 	"github.com/open-policy-agent/frameworks/constraint/pkg/core/templates"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/handler"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/schema/defaulting"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // templateClient handles per-ConstraintTemplate operations.
@@ -67,9 +66,7 @@ func (e *templateClient) ValidateConstraint(constraint *unstructured.Unstructure
 // corresponding template.
 // Assumes ValidateConstraint() called is called so the constraint is a valid CRD.
 func (e *templateClient) ApplyDefaultParams(constraint *unstructured.Unstructured) (*unstructured.Unstructured, error) {
-	cpy := constraint.DeepCopy()
-
-	params, found, err := unstructured.NestedFieldNoCopy(cpy.Object, "spec", "parameters")
+	params, found, err := unstructured.NestedFieldNoCopy(constraint.Object, "spec", "parameters")
 	if err != nil {
 		return nil, err
 	}
@@ -93,12 +90,12 @@ func (e *templateClient) ApplyDefaultParams(constraint *unstructured.Unstructure
 	if ok {
 		defaulting.Default(params, &structuralParameters)
 
-		if err := unstructured.SetNestedField(cpy.Object, params, "spec", "parameters"); err != nil {
+		if err := unstructured.SetNestedField(constraint.Object, params, "spec", "parameters"); err != nil {
 			return nil, err
 		}
 	}
 
-	return cpy, nil
+	return constraint, nil
 }
 
 func (e *templateClient) getTemplate() *templates.ConstraintTemplate {


### PR DESCRIPTION
Fixes https://github.com/open-policy-agent/frameworks/issues/326.
Fixes https://github.com/open-policy-agent/frameworks/issues/70.

Inject any defined default parameters from the ConstraintTemplate schema definition in a Constraint that does not define its parameters.