### PR TITLE
Update gatekeeper.yml to use go version 1.20

### DIFF
--- a/.github/workflows/gatekeeper.yml
+++ b/.github/workflows/gatekeeper.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up Go 1.20
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20
+          go-version: "1.20"
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3

--- a/.github/workflows/gatekeeper.yml
+++ b/.github/workflows/gatekeeper.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Set up Go 1.19
+      - name: Set up Go 1.20
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.20
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3


### PR DESCRIPTION
I think this is needed since we updated the `go.mod` in https://github.com/open-policy-agent/gatekeeper/pull/2538#discussion_r1189187165 