### PR TITLE
feat: validate unknown fields for CR

### DIFF
--- a/constraint/pkg/client/client_test.go
+++ b/constraint/pkg/client/client_test.go
@@ -868,6 +868,14 @@ func TestClient_AddConstraint(t *testing.T) {
 			wantGetConstraintError: nil,
 		},
 		{
+			name:                   "unknown fields",
+			template:               cts.New(cts.OptName("foos"), cts.OptCRDNames("Foos")),
+			constraint:             cts.MakeConstraint(t, "Foos", "foo", cts.Set(int64(3), "spec", "someRandomField")),
+			wantHandled:            nil,
+			wantAddConstraintError: constraints.ErrInvalidConstraint,
+			wantGetConstraintError: client.ErrMissingConstraint,
+		},
+		{
 			name:                   "No Name",
 			template:               cts.New(cts.OptName("foos"), cts.OptCRDNames("Foos")),
 			constraint:             cts.MakeConstraint(t, "Foos", ""),
@@ -945,10 +953,8 @@ func TestClient_AddConstraint(t *testing.T) {
 			name:     "invalid matcher",
 			template: clienttest.TemplateDeny(),
 			constraint: cts.MakeConstraint(t, clienttest.KindDeny, "constraint",
-				cts.Set(int64(3), "spec", "matchNamespace")),
-			wantAddConstraintError: &clienterrors.ErrorMap{
-				handlertest.TargetName: constraints.ErrInvalidConstraint,
-			},
+				cts.Set(int64(3), "spec", "match", "matchNamespace")),
+			wantAddConstraintError: constraints.ErrSchema,
 			wantGetConstraintError: client.ErrMissingConstraint,
 		},
 		{

--- a/constraint/pkg/client/clienttest/cts/constraints.go
+++ b/constraint/pkg/client/clienttest/cts/constraints.go
@@ -42,7 +42,7 @@ type ConstraintArg func(*unstructured.Unstructured) error
 // Namespace.
 func MatchNamespace(namespace string) ConstraintArg {
 	return func(u *unstructured.Unstructured) error {
-		return unstructured.SetNestedField(u.Object, namespace, "spec", "matchNamespace")
+		return unstructured.SetNestedField(u.Object, namespace, "spec", "match", "matchNamespace")
 	}
 }
 

--- a/constraint/pkg/client/clienttest/cts/opts.go
+++ b/constraint/pkg/client/clienttest/cts/opts.go
@@ -4,6 +4,7 @@ import (
 	"github.com/open-policy-agent/frameworks/constraint/pkg/client/drivers/rego/schema"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/core/templates"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/handler/handlertest"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 )
 
 const (
@@ -28,6 +29,11 @@ var defaults = []Opt{
 
 func New(opts ...Opt) *templates.ConstraintTemplate {
 	tmpl := &templates.ConstraintTemplate{}
+
+	tmpl.Spec.CRD.Spec.Validation = &templates.Validation{}
+	tmpl.Spec.CRD.Spec.Validation.OpenAPIV3Schema = &apiextensions.JSONSchemaProps{
+		Type: "object",
+	}
 
 	opts = append(defaults, opts...)
 	for _, opt := range opts {

--- a/constraint/pkg/client/clienttest/templates.go
+++ b/constraint/pkg/client/clienttest/templates.go
@@ -211,6 +211,9 @@ func TemplateCheckData() *templates.ConstraintTemplate {
 	ct.Spec.CRD.Spec.Validation = &templates.Validation{
 		OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 			Type: "object",
+			Properties: map[string]apiextensions.JSONSchemaProps{
+				"wantData": {Type: "string"},
+			},
 		},
 	}
 

--- a/constraint/pkg/client/crds/crds_test.go
+++ b/constraint/pkg/client/crds/crds_test.go
@@ -160,23 +160,27 @@ func TestValidateTemplate(t *testing.T) {
 func TestCreateSchema(t *testing.T) {
 	tests := []crdTestCase{
 		{
-			Name:           "Just EnforcementAction",
-			Template:       cts.New(),
-			Handler:        createTestTargetHandler(),
-			ExpectedSchema: cts.ExpectedSchema(cts.PropMap{"match": cts.PropUnstructured()}),
+			Name:     "Just EnforcementAction",
+			Template: cts.New(),
+			Handler:  createTestTargetHandler(),
+			ExpectedSchema: cts.ExpectedSchema(cts.PropMap{
+				"match":      cts.PropUnstructured(),
+				"parameters": cts.PropTyped("object"),
+			}),
 		},
 		{
-			Name:     "Just Match",
+			Name:     "Add to the match schema",
 			Template: cts.New(),
 			Handler:  createTestTargetHandler(matchSchema(cts.PropMap{"labels": cts.PropUnstructured()})),
 			ExpectedSchema: cts.ExpectedSchema(cts.PropMap{
 				"match": cts.Prop(cts.PropMap{
 					"labels": cts.PropUnstructured(),
 				}),
+				"parameters": cts.PropTyped("object"),
 			}),
 		},
 		{
-			Name:     "Just Parameters",
+			Name:     "Add to the parameters schema",
 			Template: cts.New(cts.OptCRDSchema(cts.PropMap{"test": cts.PropUnstructured()})),
 			Handler:  createTestTargetHandler(),
 			ExpectedSchema: cts.ExpectedSchema(cts.PropMap{
@@ -187,7 +191,7 @@ func TestCreateSchema(t *testing.T) {
 			}),
 		},
 		{
-			Name:     "Match and Parameters",
+			Name:     "Add to match and parameters schemas",
 			Template: cts.New(cts.OptCRDSchema(cts.PropMap{"dragon": cts.PropUnstructured()})),
 			Handler:  createTestTargetHandler(matchSchema(cts.PropMap{"fire": cts.PropUnstructured()})),
 			ExpectedSchema: cts.ExpectedSchema(cts.PropMap{
@@ -205,7 +209,8 @@ func TestCreateSchema(t *testing.T) {
 			schema := crds.CreateSchema(tc.Template, tc.Handler)
 
 			if !reflect.DeepEqual(schema, tc.ExpectedSchema) {
-				t.Errorf("Unexpected schema output.  Diff: %v", cmp.Diff(*schema, tc.ExpectedSchema))
+				diff := cmp.Diff(schema.Properties["spec"], tc.ExpectedSchema.Properties["spec"])
+				t.Errorf("Unexpected schema output.  Diff: %v", diff)
 			}
 		})
 	}

--- a/constraint/pkg/client/crds/crds_test.go
+++ b/constraint/pkg/client/crds/crds_test.go
@@ -439,6 +439,23 @@ func TestCRValidation(t *testing.T) {
 			CR:            createCR(crName("mycr"), kind("Horse"), enforcementAction("dryrun")),
 			ErrorExpected: false,
 		},
+		{
+			Name: "unknown fields",
+			Template: cts.New(
+				cts.OptName("SomeName"),
+				cts.OptCRDNames("Horse"),
+			),
+			Handler: createTestTargetHandler(),
+			CR: func() *unstructured.Unstructured {
+				cr := createCR(crName("mycr"), kind("Horse"), params(`{"fast": true}`))
+				err := unstructured.SetNestedField(cr.Object, make(map[string]interface{}), "spec", "randomField")
+				if err != nil {
+					t.Fatal(err)
+				}
+				return cr
+			}(),
+			ErrorExpected: true,
+		},
 	}
 
 	for _, tc := range tests {

--- a/constraint/pkg/client/crds/validate.go
+++ b/constraint/pkg/client/crds/validate.go
@@ -87,7 +87,7 @@ func ValidateCR(cr *unstructured.Unstructured, crd *apiextensions.CustomResource
 	}
 
 	// validate that there are no unknown fields in the CR
-	// NewStructural assumes the schema is validate
+	// NewStructural assumes the schema is valid
 	structural, err := schema.NewStructural(crd.Spec.Validation.OpenAPIV3Schema)
 	if err != nil {
 		return fmt.Errorf("%w: %v", constraints.ErrInvalidConstraint, err)

--- a/constraint/pkg/client/crds/validate.go
+++ b/constraint/pkg/client/crds/validate.go
@@ -12,6 +12,8 @@ import (
 	"github.com/open-policy-agent/frameworks/constraint/pkg/core/templates"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsvalidation "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation"
+	"k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
+	structuralpruning "k8s.io/apiextensions-apiserver/pkg/apiserver/schema/pruning"
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	apivalidation "k8s.io/apimachinery/pkg/util/validation"
@@ -82,6 +84,17 @@ func ValidateCR(cr *unstructured.Unstructured, crd *apiextensions.CustomResource
 	// Validate the schema last as this is the most expensive operation.
 	if err := validation.ValidateCustomResource(field.NewPath(""), cr, validator); err != nil {
 		return fmt.Errorf("%w: %v", constraints.ErrSchema, err.ToAggregate())
+	}
+
+	// validate that there are no unknown fields in the CR
+	// NewStructural assumes the schema is validate
+	structural, err := schema.NewStructural(crd.Spec.Validation.OpenAPIV3Schema)
+	if err != nil {
+		return fmt.Errorf("%w: %v", constraints.ErrInvalidConstraint, err)
+	}
+	unknownFields := structuralpruning.PruneWithOptions(cr.DeepCopy().Object, structural, true, schema.UnknownFieldPathOptions{TrackUnknownFieldPaths: true})
+	if len(unknownFields) > 0 {
+		return fmt.Errorf("%w: %v", constraints.ErrInvalidConstraint, fmt.Sprintf("unknown fields: %v", unknownFields))
 	}
 
 	return nil

--- a/constraint/pkg/client/template_client.go
+++ b/constraint/pkg/client/template_client.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/schema/defaulting"
-	structuralpruning "k8s.io/apiextensions-apiserver/pkg/apiserver/schema/pruning"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -60,22 +59,7 @@ func (e *templateClient) ValidateConstraint(constraint *unstructured.Unstructure
 		}
 	}
 
-	if err := crds.ValidateCR(constraint, e.crd); err != nil {
-		return err
-	}
-
-	// validate that there are no unknown fields in the CR
-	// NewStructural assumes the schema is validate
-	structural, err := schema.NewStructural(e.crd.Spec.Validation.OpenAPIV3Schema)
-	if err != nil {
-		return fmt.Errorf("%w: %v", apiconstraints.ErrInvalidConstraint, err)
-	}
-	unknownFields := structuralpruning.PruneWithOptions(constraint.DeepCopy().Object, structural, true, schema.UnknownFieldPathOptions{TrackUnknownFieldPaths: true})
-	if len(unknownFields) > 0 {
-		return fmt.Errorf("%w: %v", apiconstraints.ErrInvalidConstraint, fmt.Sprintf("unknown fields: %v", unknownFields))
-	}
-
-	return nil
+	return crds.ValidateCR(constraint, e.crd)
 }
 
 // ApplyDefaultParams will apply any default parameters defined in the CRD of the constraint's

--- a/constraint/pkg/client/template_client.go
+++ b/constraint/pkg/client/template_client.go
@@ -74,7 +74,7 @@ func (e *templateClient) ValidateConstraint(constraint *unstructured.Unstructure
 	if len(unknownFields) > 0 {
 		return fmt.Errorf("%w: %v", apiconstraints.ErrInvalidConstraint, fmt.Sprintf("unknown fields: %v", unknownFields))
 	}
-	
+
 	return nil
 }
 

--- a/constraint/pkg/client/template_client.go
+++ b/constraint/pkg/client/template_client.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/schema/defaulting"
+	structuralpruning "k8s.io/apiextensions-apiserver/pkg/apiserver/schema/pruning"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -59,7 +60,22 @@ func (e *templateClient) ValidateConstraint(constraint *unstructured.Unstructure
 		}
 	}
 
-	return crds.ValidateCR(constraint, e.crd)
+	if err := crds.ValidateCR(constraint, e.crd); err != nil {
+		return err
+	}
+
+	// validate that there are no unknown fields in the CR
+	// NewStructural assumes the schema is validate
+	structural, err := schema.NewStructural(e.crd.Spec.Validation.OpenAPIV3Schema)
+	if err != nil {
+		return fmt.Errorf("%w: %v", apiconstraints.ErrInvalidConstraint, err)
+	}
+	unknownFields := structuralpruning.PruneWithOptions(constraint.DeepCopy().Object, structural, true, schema.UnknownFieldPathOptions{TrackUnknownFieldPaths: true})
+	if len(unknownFields) > 0 {
+		return fmt.Errorf("%w: %v", apiconstraints.ErrInvalidConstraint, fmt.Sprintf("unknown fields: %v", unknownFields))
+	}
+	
+	return nil
 }
 
 // ApplyDefaultParams will apply any default parameters defined in the CRD of the constraint's

--- a/constraint/pkg/handler/handlertest/handler.go
+++ b/constraint/pkg/handler/handlertest/handler.go
@@ -82,7 +82,7 @@ func (h *Handler) MatchSchema() apiextensions.JSONSchemaProps {
 	return apiextensions.JSONSchemaProps{
 		Type: "object",
 		Properties: map[string]apiextensions.JSONSchemaProps{
-			"label": {Type: "string"},
+			"matchNamespace": {Type: "string"},
 		},
 	}
 }
@@ -109,7 +109,7 @@ func (h *Handler) ValidateConstraint(constraint *unstructured.Unstructured) erro
 }
 
 func (h *Handler) ToMatcher(constraint *unstructured.Unstructured) (constraints.Matcher, error) {
-	ns, _, err := unstructured.NestedString(constraint.Object, "spec", "matchNamespace")
+	ns, _, err := unstructured.NestedString(constraint.Object, "spec", "match", "matchNamespace")
 	if err != nil {
 		return nil, fmt.Errorf("unable to get spec.matchNamespace: %w", err)
 	}


### PR DESCRIPTION
This patch adds validation for unknown fields for a Custom Resource (CR) according to its schema.

This extra validation now requires that we update the test handler and test clients to comply with said validation.