### PR TITLE
fix: `anyObject` was not fully plumbed to compiler, streamline plumbing to fix

### DIFF
--- a/constraint/pkg/client/drivers/k8scel/transform/cel_snippets.go
+++ b/constraint/pkg/client/drivers/k8scel/transform/cel_snippets.go
@@ -159,13 +159,11 @@ func BindParamsV1Beta1() admissionregistrationv1beta1.Variable {
 	}
 }
 
-func BindParamsCEL() []cel.NamedExpressionAccessor {
+func BindParamsCEL() cel.NamedExpressionAccessor {
 	v := BindParamsV1Beta1()
-	return []cel.NamedExpressionAccessor{
-		&validatingadmissionpolicy.Variable{
-			Name:       v.Name,
-			Expression: v.Expression,
-		},
+	return &validatingadmissionpolicy.Variable{
+		Name:       v.Name,
+		Expression: v.Expression,
 	}
 }
 
@@ -176,13 +174,11 @@ func BindObjectV1Beta1() admissionregistrationv1beta1.Variable {
 	}
 }
 
-func BindObjectCEL() []cel.NamedExpressionAccessor {
+func BindObjectCEL() cel.NamedExpressionAccessor {
 	v := BindObjectV1Beta1()
-	return []cel.NamedExpressionAccessor{
-		&validatingadmissionpolicy.Variable{
-			Name:       v.Name,
-			Expression: v.Expression,
-		},
+	return &validatingadmissionpolicy.Variable{
+		Name:       v.Name,
+		Expression: v.Expression,
 	}
 }
 
@@ -196,7 +192,15 @@ func AllMatchersV1Beta1() []admissionregistrationv1beta1.MatchCondition {
 }
 
 func AllVariablesCEL() []cel.NamedExpressionAccessor {
-	return BindParamsCEL()
+	vars := AllVariablesV1Beta1()
+	xform := make([]cel.NamedExpressionAccessor, len(vars))
+	for i := range vars {
+		xform[i] = &validatingadmissionpolicy.Variable{
+			Name:       vars[i].Name,
+			Expression: vars[i].Expression,
+		}
+	}
+	return xform
 }
 
 func AllVariablesV1Beta1() []admissionregistrationv1beta1.Variable {

--- a/constraint/pkg/client/drivers/k8scel/transform/cel_snippets_test.go
+++ b/constraint/pkg/client/drivers/k8scel/transform/cel_snippets_test.go
@@ -258,7 +258,7 @@ func TestMatchKinds(t *testing.T) {
 				t.Fatal(err)
 			}
 			celOpts := cel.OptionalVariableDeclarations{HasParams: true}
-			filterCompiler.CompileAndStoreVariables(BindParamsCEL(), celOpts, environment.StoredExpressions)
+			filterCompiler.CompileAndStoreVariables(AllVariablesCEL(), celOpts, environment.StoredExpressions)
 			matcher := matchconditions.NewMatcher(filterCompiler.Compile(MatchKindsCEL(), celOpts, environment.StoredExpressions), ptr.To[v1.FailurePolicyType](v1.Fail), "matchTest", "kind", test.name)
 
 			obj := &unstructured.Unstructured{}
@@ -463,7 +463,7 @@ func TestMatchNameGlob(t *testing.T) {
 					t.Fatal(err)
 				}
 				celOpts := cel.OptionalVariableDeclarations{HasParams: true}
-				filterCompiler.CompileAndStoreVariables(BindParamsCEL(), celOpts, environment.StoredExpressions)
+				filterCompiler.CompileAndStoreVariables(AllVariablesCEL(), celOpts, environment.StoredExpressions)
 				matcher := matchconditions.NewMatcher(filterCompiler.Compile(MatchNameGlobCEL(), celOpts, environment.StoredExpressions), ptr.To[v1.FailurePolicyType](v1.Fail), "matchTest", "name", test.name)
 
 				constraint := &unstructured.Unstructured{Object: map[string]interface{}{}}
@@ -633,7 +633,7 @@ func TestMatchNamespacesGlob(t *testing.T) {
 					t.Fatal(err)
 				}
 				celOpts := cel.OptionalVariableDeclarations{HasParams: true}
-				filterCompiler.CompileAndStoreVariables(BindParamsCEL(), celOpts, environment.StoredExpressions)
+				filterCompiler.CompileAndStoreVariables(AllVariablesCEL(), celOpts, environment.StoredExpressions)
 				matcher := matchconditions.NewMatcher(filterCompiler.Compile(MatchNamespacesGlobCEL(), celOpts, environment.StoredExpressions), ptr.To[v1.FailurePolicyType](v1.Fail), "matchTest", "name", test.name)
 
 				versionedAttributes, err := RequestToVersionedAttributes(subTest.request)
@@ -807,7 +807,7 @@ func TestMatchExcludedNamespacesGlob(t *testing.T) {
 					t.Fatal(err)
 				}
 				celOpts := cel.OptionalVariableDeclarations{HasParams: true}
-				filterCompiler.CompileAndStoreVariables(BindParamsCEL(), celOpts, environment.StoredExpressions)
+				filterCompiler.CompileAndStoreVariables(AllVariablesCEL(), celOpts, environment.StoredExpressions)
 				matcher := matchconditions.NewMatcher(filterCompiler.Compile(MatchExcludedNamespacesGlobCEL(), celOpts, environment.StoredExpressions), ptr.To[v1.FailurePolicyType](v1.Fail), "matchTest", "name", test.name)
 
 				versionedAttributes, err := RequestToVersionedAttributes(subTest.request)
@@ -871,7 +871,7 @@ func TestParamsBinding(t *testing.T) {
 				t.Fatal(err)
 			}
 			celOpts := cel.OptionalVariableDeclarations{HasParams: true}
-			filterCompiler.CompileAndStoreVariables(BindParamsCEL(), celOpts, environment.StoredExpressions)
+			filterCompiler.CompileAndStoreVariables(AllVariablesCEL(), celOpts, environment.StoredExpressions)
 			matcher := matchconditions.NewMatcher(
 				filterCompiler.Compile(
 					[]cel.ExpressionAccessor{
@@ -952,7 +952,7 @@ func TestObjectBinding(t *testing.T) {
 				t.Fatal(err)
 			}
 			celOpts := cel.OptionalVariableDeclarations{HasParams: true}
-			filterCompiler.CompileAndStoreVariables(BindObjectCEL(), celOpts, environment.StoredExpressions)
+			filterCompiler.CompileAndStoreVariables(AllVariablesCEL(), celOpts, environment.StoredExpressions)
 			matcher := matchconditions.NewMatcher(
 				filterCompiler.Compile(
 					[]cel.ExpressionAccessor{


### PR DESCRIPTION
variables.anyObject isn't recognized in-process until this is merged.