### PR TITLE
rego: fail closed on external_data provider errors

### DIFF
--- a/constraint/pkg/client/drivers/rego/builtin.go
+++ b/constraint/pkg/client/drivers/rego/builtin.go
@@ -1,7 +1,6 @@
 package rego
 
 import (
-	"net/http"
 	"time"
 
 	"github.com/open-policy-agent/opa/v1/ast"
@@ -64,17 +63,17 @@ func externalDataBuiltin(d *Driver) func(bctx rego.BuiltinContext, regorequest *
 		if len(providerRequestKeys) > 0 {
 			provider, err := d.providerCache.Get(regoReq.ProviderName)
 			if err != nil {
-				return externaldata.HandleError(http.StatusBadRequest, err)
+				return nil, err
 			}
 
 			clientCert, err := d.getTLSCertificate()
 			if err != nil {
-				return externaldata.HandleError(http.StatusBadRequest, err)
+				return nil, err
 			}
 
 			externaldataResponse, statusCode, err := d.sendRequestToProvider(bctx.Context, &provider, providerRequestKeys, clientCert)
 			if err != nil {
-				return externaldata.HandleError(statusCode, err)
+				return nil, err
 			}
 
 			// update provider response cache if it is enabled

--- a/constraint/pkg/client/drivers/rego/driver_unit_test.go
+++ b/constraint/pkg/client/drivers/rego/driver_unit_test.go
@@ -864,13 +864,16 @@ func TestDriver_ExternalData(t *testing.T) {
 						[]*unstructured.Unstructured{cts.MakeConstraint(t, "Fakes", "foo-1")},
 						map[string]interface{}{"hi": "there"},
 					)
+					if tt.errorExpected {
+						if err == nil {
+							t.Fatalf("got Query() error = nil, want non-nil")
+						}
+						return
+					}
 					if err != nil {
-						t.Fatalf("got Query() error = %v, want %v", err, nil)
+						t.Fatalf("got Query() error = %v, want nil", err)
 					}
-					if tt.errorExpected && len(qr.Results) == 0 {
-						t.Fatalf("got 0 errors on normal query; want 1")
-					}
-					if !tt.errorExpected && len(qr.Results) > 0 {
+					if len(qr.Results) > 0 {
 						t.Fatalf("got %d errors on normal query; want 0", len(qr.Results))
 					}
 				})


### PR DESCRIPTION
### Motivation
- Fix a fail-open vulnerability where `external_data` builtin converted provider/cache/TLS/HTTP/JSON errors into a normal Rego response term, allowing constraints to be bypassed if they ignore `system_error`.

### Description
- Return builtin errors from the Rego `external_data` implementation instead of encoding failures into a `RegoResponse`, by replacing `externaldata.HandleError(...)` with `return nil, err` in `constraint/pkg/client/drivers/rego/builtin.go`.
- Remove the now-unused `net/http` import from `constraint/pkg/client/drivers/rego/builtin.go`.
- Update `TestDriver_ExternalData` in `constraint/pkg/client/drivers/rego/driver_unit_test.go` so failure scenarios assert that `Query` returns a non-nil error while successful responses keep the existing behavior.

### Testing
- Attempted to run the external-data focused unit tests with `go test ./pkg/client/drivers/rego -run TestDriver_ExternalData -count=1`, but the run timed out in this environment (`EXIT:124`).
- Attempted a focused test `go test -v ./pkg/client/drivers/rego -run 'TestDriver_ExternalData/provider_not_found' -count=1`, which also timed out in this environment (`EXIT:124`).
- No other automated tests completed in this environment due to timeouts, but the change is minimal and confined to the builtin error propagation and its unit test expectations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7efec3cb0832a93d40536418884a3)