### PR TITLE
fix: bumping on goluncheck sha that pins deps to full commit

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -32,6 +32,6 @@ jobs:
         with:
           go-version: "1.25"
           check-latest: true
-      - uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
+      - uses: golang/govulncheck-action@31f7c5463448f83528bd771c2d978d940080c9fd # unreleased, includes fix for golang/go#75908
         with:
           work-dir: constraint


### PR DESCRIPTION
Pin golang/govulncheck-action to 31f7c5463448f83528bd771c2d978d940080c9fd
which includes a fix for pinning internal action dependencies to full
commit SHAs (https://github.com/golang/go/issues/75908). This is required for repositories that
enforce the GitHub Actions SHA-pinning policy. The fix has not yet been
included in a release (latest is v1.0.4).